### PR TITLE
Allow detective to only get roles with faction time set to 0

### DIFF
--- a/TownOfUs/Modules/GameHistory.cs
+++ b/TownOfUs/Modules/GameHistory.cs
@@ -65,7 +65,7 @@ public sealed class BodyReport
 
     public static string ParseDetectiveReport(BodyReport br)
     {
-        if (br.KillAge > OptionGroupSingleton<DetectiveOptions>.Instance.DetectiveFactionDuration * 1000)
+        if (br.KillAge > OptionGroupSingleton<DetectiveOptions>.Instance.DetectiveFactionDuration * 1000 && br.KillAge > OptionGroupSingleton<DetectiveOptions>.Instance.DetectiveRoleDuration * 1000)
         {
             return
                 $"Body Report: The corpse is too old to gain information from. (Killed {Math.Round(br.KillAge / 1000)}s ago)";


### PR DESCRIPTION
Pretty simple patch, but allows the time to get faction to be set to 0 if you just want the detective to get the role. For example, you could have time to get the role be set to 30 seconds while the time to get the faction is 0. It can be fixed by having the time to get faction set to the same time to get role, but this just makes it less confusing if you set the time to get faction to 0.