### PR TITLE
fixes another transporter oob bug

### DIFF
--- a/TownOfUs/Roles/Crewmate/TransporterRole.cs
+++ b/TownOfUs/Roles/Crewmate/TransporterRole.cs
@@ -228,11 +228,11 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
         }
 
         var positions = GetAdjustedPositions(t1, t2);
-        if (t1.TryCast<PlayerControl>() != null)
+        if (t1.TryCast<PlayerControl>() != null && t2.TryCast<DeadBody>() != null)
         {
             positions.Item1 = play1.Collider.bounds.center;
         }
-        if (t2.TryCast<PlayerControl>() != null)
+        if (t2.TryCast<PlayerControl>() != null && t1.TryCast<DeadBody>() != null)
         {
             positions.Item2 = play2.Collider.bounds.center;
         }


### PR DESCRIPTION
My previous transporter OOB fix accidentally introduced a bug where mini & giant could be put out of bounds/put people out of bounds.

This is very simple, they have different center points so since both players were alive it was using the centerpoint of the mini, which can get it put into places like the lava on polus.

