### PR TITLE
Added the Role Seeker modifier using placeholder icons.

### DIFF
--- a/TownOfUs/Events/Impostor/RoleSeekerEvents.cs
+++ b/TownOfUs/Events/Impostor/RoleSeekerEvents.cs
@@ -1,0 +1,141 @@
+﻿using MiraAPI.Events;
+using MiraAPI.Modifiers;
+using MiraAPI.Events.Vanilla.Gameplay;
+using TownOfUs.Modifiers.Game;
+using TownOfUs.Modifiers.Game.Impostor;
+using Il2CppInterop.Runtime.Attributes;
+using TownOfUs.Utilities;
+using TownOfUs.Options.Modifiers.Impostor;
+using MiraAPI.GameOptions;
+
+namespace TownOfUs.Events.Modifiers
+{
+    public static class RoleSeekerEvents
+    {
+        public static float InGameReveal = OptionGroupSingleton<RoleSeekerOptions>.Instance.InGameReveal;
+        public static float NotInGameReveal = OptionGroupSingleton<RoleSeekerOptions>.Instance.NotInGameReveal;
+
+        private static readonly IReadOnlyList<string> ImpostorRoles = new List<string>
+        {
+            "Ambassador", "Ambusher", "Blackmailer", "Bomber", "Eclipsal", "Escapist",
+            "Grenadier", "Hypnotist", "Janitor", "Miner", "Morphling", "Scavenger",
+            "Swooper", "Traitor", "Undertaker", "Venerer", "Warlock"
+        };
+
+        private static readonly IReadOnlyList<string> PossibleRoles = new List<string>
+        {
+            "Altruist", "Ambassador", "Ambusher", "Amnesiac", "Arsonist", "Aurial", "Blackmailer", "Bomber",
+            "Cleric", "Deputy", "Detective", "Doomsayer", "Eclipsal", "Engineer", "Escapist", "Executioner",
+            "Glitch", "Grenadier", "Guardian Angel", "Haunter", "Hunter", "Hypnotist", "Imitator", "Inquisitor",
+            "Investigator", "Jailor", "Janitor", "Jester", "Juggernaut", "Lookout", "Mayor", "Medic", "Medium",
+            "Mercenary", "Miner", "Mirrorcaster", "Morphling", "Mystic", "Oracle", "Pestilence", "Phantom",
+            "Plaguebearer", "Plumber", "Politician", "Prosecutor", "Scavenger", "Seer", "Sheriff", "Snitch",
+            "Soul Collector", "Spy", "Survivor", "Swapper", "Swooper", "Tracker", "Traitor", "Trapper",
+            "Transporter", "Undertaker", "Vampire", "Venerer", "Veteran", "Vigilante", "Warlock", "Warden",
+            "Werewolf"
+        };
+
+        [HideFromIl2Cpp] 
+        public static List<RoleBehaviour> PotentiallyRevealedRoles { get; set; } = new();
+
+        [HideFromIl2Cpp] 
+        private static Dictionary<string, int> InGameRoleCounts { get; set; } = new();
+
+        [HideFromIl2Cpp] 
+        private static Dictionary<string, int> RevealedInGameRoles { get; set; } = new();
+
+        [HideFromIl2Cpp] 
+        private static HashSet<string> RevealedNotInGameRoles { get; set; } = new();
+
+        [RegisterEvent]
+        public static void GameStartEventHandler(RoundStartEvent @event)
+        {
+            if (!@event.TriggeredByIntro)
+                return;
+
+            if (!PlayerControl.LocalPlayer.HasModifier<RoleSeekerModifier>())
+                return;
+
+            PotentiallyRevealedRoles.Clear();
+            InGameRoleCounts.Clear();
+            RevealedInGameRoles.Clear();
+            RevealedNotInGameRoles.Clear();
+
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                if (player.Data?.Role != null)
+                {
+                    PotentiallyRevealedRoles.Add(player.Data.Role);
+                    var roleName = player.Data.Role.NiceName;
+                    if (!InGameRoleCounts.ContainsKey(roleName))
+                        InGameRoleCounts[roleName] = 0;
+                    InGameRoleCounts[roleName]++;
+                }
+            }
+        }
+
+        [RegisterEvent]
+        public static void AfterMurderEventHandler(AfterMurderEvent @event)
+        {
+            var source = @event.Source;
+
+            if (source.GetModifier<RoleSeekerModifier>() == null)
+                return;
+
+            if (source.TryGetModifier<AllianceGameModifier>(out var allyMod) && !allyMod.GetsPunished)
+                return;
+
+            if (PotentiallyRevealedRoles.Count <= 0 || !source.HasModifier<RoleSeekerModifier>())
+                return;
+
+            float roll = UnityEngine.Random.value;
+            string? roleName = null;
+            bool? inGame = null;
+
+            var inGameRoleNames = PotentiallyRevealedRoles
+                .Select(r => r.NiceName)
+                .Where(r => !ImpostorRoles.Contains(r))
+                .ToList();
+
+            if (roll < InGameReveal / 100f && inGameRoleNames.Count > 0)
+            {
+                var availableRoles = inGameRoleNames
+                    .Where(r => !RevealedInGameRoles.ContainsKey(r) || RevealedInGameRoles[r] < InGameRoleCounts[r])
+                    .ToList();
+
+                if (availableRoles.Count > 0)
+                {
+                    roleName = availableRoles[UnityEngine.Random.Range(0, availableRoles.Count)];
+                    inGame = true;
+                    if (!RevealedInGameRoles.ContainsKey(roleName))
+                        RevealedInGameRoles[roleName] = 0;
+                    RevealedInGameRoles[roleName]++;
+                }
+            }
+            else
+            {
+                var notInGameRoles = PossibleRoles
+                    .Where(r => !inGameRoleNames.Contains(r) && !ImpostorRoles.Contains(r) && !RevealedNotInGameRoles.Contains(r))
+                    .ToList();
+
+                if (notInGameRoles.Count > 0)
+                {
+                    roleName = notInGameRoles[UnityEngine.Random.Range(0, notInGameRoles.Count)];
+                    inGame = false;
+                    RevealedNotInGameRoles.Add(roleName);
+                }
+            }
+
+            if (roleName != null && inGame.HasValue)
+            {
+                var prefix = roleName.StartsWithVowel() ? "an" : "a";
+                var title = "<color=#D64042>Role Seeker Info</color>";
+                string message = inGame.Value
+                    ? $"<color=#FFFFFF>You have revealed that {prefix} {roleName} is in this game!</color>"
+                    : $"<color=#FFFFFF>You have revealed that {prefix} {roleName} is not in this game!</color>";
+
+                MiscUtils.AddFakeChat(PlayerControl.LocalPlayer.Data, title, message, false, true);
+            }
+        }
+    }
+}

--- a/TownOfUs/Modifiers/Game/Impostor/RoleSeekerModifier.cs
+++ b/TownOfUs/Modifiers/Game/Impostor/RoleSeekerModifier.cs
@@ -1,0 +1,45 @@
+﻿using MiraAPI.GameOptions;
+using MiraAPI.Utilities.Assets;
+using TownOfUs.Options.Modifiers;
+using UnityEngine;
+using TownOfUs.Utilities;
+
+namespace TownOfUs.Modifiers.Game.Impostor;
+
+public sealed class RoleSeekerModifier : TouGameModifier, IWikiDiscoverable
+{
+    public override string ModifierName => TouLocale.Get(TouNames.RoleSeeker, "Role Seeker");
+    public override string IntroInfo => "You will reveal a role which is or isn't in this game every kill.";
+    public override LoadableAsset<Sprite>? ModifierIcon => TouModifierIcons.Telepath;
+
+    public override ModifierFaction FactionType => ModifierFaction.ImpostorPassive;
+    public override Color FreeplayFileColor => new Color32(255, 25, 25, 255);
+
+    public string GetAdvancedDescription()
+    {
+        return
+            "You will reveal a role which either is or isn't in this game every time you kill.";
+    }
+
+    public List<CustomButtonWikiDescription> Abilities { get; } = [];
+
+    public override string GetDescription()
+    {
+        return "Reveal roles which are or aren't in-game.";
+    }
+
+    public override int GetAssignmentChance()
+    {
+        return (int)OptionGroupSingleton<ImpostorModifierOptions>.Instance.RoleSeekerChance;
+    }
+
+    public override int GetAmountPerGame()
+    {
+        return (int)OptionGroupSingleton<ImpostorModifierOptions>.Instance.RoleSeekerAmount;
+    }
+
+    public override bool IsModifierValidOn(RoleBehaviour role)
+    {
+        return base.IsModifierValidOn(role) && role.IsImpostor();
+    }
+}

--- a/TownOfUs/Modules/Localization/TouNames.cs
+++ b/TownOfUs/Modules/Localization/TouNames.cs
@@ -94,6 +94,7 @@ public enum TouNames
     Saboteur,
     Telepath,
     Underdog,
+    RoleSeeker,
     // Assailant Modifiers (NK/Imp)
     Assassin,
     DoubleShot,

--- a/TownOfUs/Options/Modifiers/Impostor/RoleSeekerOptions.cs
+++ b/TownOfUs/Options/Modifiers/Impostor/RoleSeekerOptions.cs
@@ -1,0 +1,21 @@
+﻿using MiraAPI.GameOptions;
+using MiraAPI.GameOptions.Attributes;
+using MiraAPI.GameOptions.OptionTypes;
+using MiraAPI.Utilities;
+using TownOfUs.Modifiers.Game.Impostor;
+using UnityEngine;
+
+namespace TownOfUs.Options.Modifiers.Impostor;
+
+public sealed class RoleSeekerOptions : AbstractOptionGroup<RoleSeekerModifier>
+{
+    public override string GroupName => TouLocale.Get(TouNames.Telepath, "Role Seeker");
+    public override Color GroupColor => Palette.ImpostorRoleHeaderRed;
+    public override uint GroupPriority => 42;
+
+    [ModdedNumberOption("Reveal In-Game Role Chance", 0f, 100f, 5f, MiraNumberSuffixes.Percent)]
+    public float InGameReveal { get; set; } = 40f;
+
+    [ModdedNumberOption("Reveal Not In-Game Role Chance", 0f, 100f, 5f, MiraNumberSuffixes.Percent)]
+    public float NotInGameReveal { get; set; } = 60f;
+}

--- a/TownOfUs/Options/Modifiers/ImpostorModifierOptions.cs
+++ b/TownOfUs/Options/Modifiers/ImpostorModifierOptions.cs
@@ -57,4 +57,13 @@ public sealed class ImpostorModifierOptions : AbstractOptionGroup
         {
             Visible = () => OptionGroupSingleton<ImpostorModifierOptions>.Instance.UnderdogAmount > 0
         };
+
+    [ModdedNumberOption("Role Seeker Amount", 0, 5)]
+    public float RoleSeekerAmount { get; set; } = 0;
+
+    public ModdedNumberOption RoleSeekerChance { get; } =
+        new("Role Seeker Chance", 50f, 0, 100f, 10f, MiraNumberSuffixes.Percent)
+        {
+            Visible = () => OptionGroupSingleton<ImpostorModifierOptions>.Instance.RoleSeekerAmount > 0
+        };
 }


### PR DESCRIPTION
The Role Seeker modifier is an Impostor Passive modifier which reveals roles that are or aren't in the current game to the Impostor  with the modifier every time the Impostor gets a kill, the chance on whether a role which is in-game or not in-game will be revealed is configurable in the settings.