### PR TITLE
add null guards

### DIFF
--- a/TownOfUs/Patches/Options/TeamChatPatches.cs
+++ b/TownOfUs/Patches/Options/TeamChatPatches.cs
@@ -862,9 +862,9 @@ public static class TeamChatPatches
         public static void Postfix(ChatController __instance)
         {
             if (
-                !__instance.IsOpenOrOpening ||
-                __instance == null ||
-                __instance.Pointer == IntPtr.Zero
+                __instance is null ||
+                __instance.Pointer == IntPtr.Zero ||
+                !__instance.IsOpenOrOpening
             ) return;
 
             if (TeamChatActive && !ForceReset)

--- a/TownOfUs/Patches/Options/TeamChatPatches.cs
+++ b/TownOfUs/Patches/Options/TeamChatPatches.cs
@@ -861,12 +861,12 @@ public static class TeamChatPatches
     {
         public static void Postfix(ChatController __instance)
         {
-            if (!__instance.IsOpenOrOpening)
-            {
-                return;
-            }
+            if (
+                !__instance.IsOpenOrOpening ||
+                __instance == null ||
+                __instance.Pointer == IntPtr.Zero
+            ) return;
 
-            // Ensure that opening chat reflects the currently-selected custom chat mode.
             if (TeamChatActive && !ForceReset)
             {
                 UpdateChat();
@@ -876,15 +876,22 @@ public static class TeamChatPatches
                 (PlayerControl.LocalPlayer.IsLover() && MeetingHud.Instance == null || TeamChatActive))
             {
                 var sprite = PrivateChatDot.GetComponent<SpriteRenderer>();
-                sprite.enabled = false;
+                if (sprite != null) sprite.enabled = false;
             }
 
             if (!TeamChatActive || ForceReset)
             {
                 ForceReset = false;
+
                 var ChatScreenContainer = GameObject.Find("ChatScreenContainer");
+                if (ChatScreenContainer == null) return;
+
                 var Background = ChatScreenContainer.transform.FindChild("Background");
+                if (Background == null) return;
+
                 var bubbleItems = GameObject.Find("Items");
+                if (bubbleItems == null) return;
+
                 foreach (var bubble in bubbleItems.GetAllChildren())
                 {
                     bubble.gameObject.SetActive(true);
@@ -893,10 +900,15 @@ public static class TeamChatPatches
                         bubble.gameObject.SetActive(false);
                     }
                 }
-                var chat = HudManager.Instance.Chat;
+
+                var chat = HudManager.Instance?.Chat;
+                if (chat == null) return;
+
                 calledByChatUpdate = true;
                 chat.AlignAllBubbles();
-                Background.GetComponent<SpriteRenderer>().color = Color.white;
+
+                var bgRenderer = Background.GetComponent<SpriteRenderer>();
+                if (bgRenderer != null) bgRenderer.color = Color.white;
             }
 
             if (TeamChatButton)

--- a/TownOfUs/Patches/Roles/ChatControllerPatches.cs
+++ b/TownOfUs/Patches/Roles/ChatControllerPatches.cs
@@ -22,6 +22,12 @@ public static class ChatControllerPatches
     [HarmonyPatch(nameof(ChatController.Awake))]
     public static void AwakePostfix(ChatController __instance)
     {
+        if (
+            __instance == null ||
+            __instance.Pointer == IntPtr.Zero ||
+            __instance.sendRateMessageText == null
+        ) return;
+
         _noticeText =
             Object.Instantiate(__instance.sendRateMessageText, __instance.sendRateMessageText.transform.parent);
         _noticeText.text = string.Empty;
@@ -31,10 +37,15 @@ public static class ChatControllerPatches
     [HarmonyPatch(nameof(ChatController.UpdateChatMode))]
     public static void UpdateChatModePostfix(ChatController __instance)
     {
+        if (__instance == null || __instance.Pointer == IntPtr.Zero) return;
+
         if (_noticeText == null || !PlayerControl.LocalPlayer)
         {
             return;
         }
+
+        var localData = PlayerControl.LocalPlayer.Data;
+        if (localData == null) return;
 
         if (!MeetingHud.Instance)
         {
@@ -47,37 +58,37 @@ public static class ChatControllerPatches
         }
 
         if (PlayerControl.LocalPlayer.HasModifier<BlackmailedModifier>() &&
-            !PlayerControl.LocalPlayer.Data.IsDead)
+            !localData.IsDead)
         {
             _noticeText.text = "You have been blackmailed.";
-            __instance.freeChatField.SetVisible(false);
-            __instance.quickChatField.SetVisible(false);
+            __instance.freeChatField?.SetVisible(false);
+            __instance.quickChatField?.SetVisible(false);
         }
-        else if (TeamChatPatches.TeamChatActive && !PlayerControl.LocalPlayer.Data.IsDead)
+        else if (TeamChatPatches.TeamChatActive && !localData.IsDead)
         {
             _noticeText.text = string.Empty;
-            __instance.freeChatField.SetVisible(true);
-            __instance.quickChatField.SetVisible(false);
+            __instance.freeChatField?.SetVisible(true);
+            __instance.quickChatField?.SetVisible(false);
         }
         else if (PlayerControl.LocalPlayer.HasModifier<JailedModifier>() &&
-                 !PlayerControl.LocalPlayer.Data.IsDead && !TeamChatPatches.TeamChatActive)
+                 !localData.IsDead && !TeamChatPatches.TeamChatActive)
         {
             var canChat = OptionGroupSingleton<JailorOptions>.Instance.JaileePublicChat;
             if (canChat)
             {
                 _noticeText.text = "You are jailed. You can use public chat.";
-                __instance.freeChatField.SetVisible(true);
+                __instance.freeChatField?.SetVisible(true);
             }
             else
             {
                 _noticeText.text = "You are jailed. You cannot use public chat.";
-                __instance.freeChatField.SetVisible(false);
-                __instance.quickChatField.SetVisible(false);
+                __instance.freeChatField?.SetVisible(false);
+                __instance.quickChatField?.SetVisible(false);
             }
         }
         else
         {
-            __instance.freeChatField.SetVisible(true);
+            __instance.freeChatField?.SetVisible(true);
             _noticeText.text = string.Empty;
         }
     }

--- a/TownOfUs/Patches/Roles/ChatControllerPatches.cs
+++ b/TownOfUs/Patches/Roles/ChatControllerPatches.cs
@@ -23,7 +23,7 @@ public static class ChatControllerPatches
     public static void AwakePostfix(ChatController __instance)
     {
         if (
-            __instance == null ||
+            __instance is null ||
             __instance.Pointer == IntPtr.Zero ||
             __instance.sendRateMessageText == null
         ) return;
@@ -45,7 +45,6 @@ public static class ChatControllerPatches
         }
 
         var localData = PlayerControl.LocalPlayer.Data;
-        if (localData == null) return;
 
         if (!MeetingHud.Instance)
         {


### PR DESCRIPTION
So, for the first time i my life, I saw someone actually have their BepInEx ErrorLog.log (or whatever the file is called)

```
Fatal error. 0xC0000005
   at Il2CppInterop.Runtime.IL2CPP.il2cpp_runtime_invoke(IntPtr, IntPtr, Void**, IntPtr ByRef)
   at DynamicClass.DMD<ChatController::Toggle>(ChatController)
   at DynamicClass.(il2cpp -> managed) Toggle(il2cpp -> managed) Toggle(IntPtr, Il2CppInterop.Runtime.Runtime.Il2CppMethodInfo*)
   at Il2CppInterop.Runtime.IL2CPP.il2cpp_runtime_invoke(IntPtr, IntPtr, Void**, IntPtr ByRef)
   at DynamicClass.DMD<PassiveButton::ReceiveClickDown>(PassiveButton)
   at DynamicClass.(il2cpp -> managed) ReceiveClickDown(il2cpp -> managed) ReceiveClickDown(IntPtr, Il2CppInterop.Runtime.Runtime.Il2CppMethodInfo*)
```

I automatically assumed this was some sort of issue in the prerelease because again, I've never seen this before.

I'm gonna be honest, this looks like hieroglyphics to me, so i looked it up.

**0xC0000005** means STATUS_ACCESS_VIOLATION. The CPU tried to use a memory address it wasn't allowed to, i.e. writing to read only memory or null-related tomfoolery.

Anyway, then I saw it had to do with Toggle and ChatController, so I just ran a command to check for every instance of ChatController

```powershell
Get-ChildItem -Recurse -Filter "*.cs" | Select-String "ChatController"
```

Eventually I found it, so I jam-packed it with a bunch of null guards, along with another function I thought might cause issues(?)

I'm decently new to the codebase, but I've been wanting to contribute for a while. A lot of the stuff I checked to make sure it wasn't null I don't even know if it could be null in the first place because a lot of elements when I hover over them in Visual Studio say something like `object is not null here`. But I thought better to be safe than sorry, yknow?

If I'm the idiot go ahead and tell me, it's not gonna hurt my feelings if I'm wrong, and I'd rather know for next time anyway.