### PR TITLE
Added Misguess Summary for more Post-Game Clarity

### DIFF
--- a/TownOfUs/Modifiers/DeathHandlerModifier.cs
+++ b/TownOfUs/Modifiers/DeathHandlerModifier.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections;
+using AmongUs.GameOptions;
 using MiraAPI.Modifiers;
+using MiraAPI.Utilities;
 using Reactor.Networking.Attributes;
 using Reactor.Networking.Rpc;
 using Reactor.Utilities;
@@ -73,12 +75,25 @@ public sealed class DeathHandlerModifier : BaseModifier
     }
 
     [MethodRpc((uint)TownOfUsRpc.MisguessSummary, LocalHandling = RpcLocalHandling.After)]
-    public static void RpcSetMisguessSummary(PlayerControl player, byte victimId, string roleText)
+    public static void RpcSetMisguessSummary(PlayerControl player, byte victimId, uint guessId, bool isRole)
     {
+        var text = string.Empty;
+        if (isRole)
+        {
+            var role = RoleManager.Instance.GetRole((RoleTypes)guessId);
+            text = $"{role.TeamColor.ToTextColor()}{role.GetRoleName()}</color>";
+        }
+        else
+        {
+            var modifier = ModifierManager.Modifiers.FirstOrDefault(x => x.TypeId == guessId)!;
+            text =
+                $"{MiscUtils.GetRoleColour(modifier.ModifierName.Replace(" ", string.Empty)).ToTextColor()}{modifier.ModifierName}</color>";
+        }
+
         var name = GameData.Instance?.GetPlayerById(victimId)?.Object?.Data?.PlayerName ?? "?";
         var summary = TouLocale.GetParsed("MisguessSummary")
             .Replace("<player>", name)
-            .Replace("<role>", roleText);
+            .Replace("<role>", text);
 
         Coroutines.Start(CoSetExtended(player, summary));
     }

--- a/TownOfUs/Modifiers/DeathHandlerModifier.cs
+++ b/TownOfUs/Modifiers/DeathHandlerModifier.cs
@@ -37,6 +37,10 @@ public sealed class DeathHandlerModifier : BaseModifier
     // This will specify how the player died such as; Suicide, Prosecuted, Ejected, Rampaged, Reaped, etc.
     public string CauseOfDeath { get; set; } = "Suicide";
 
+    // Optional verbose cause of death used only by the extended end-game summary.
+    // The HUD and short summary keep showing the concise CauseOfDeath.
+    public string ExtendedCauseOfDeath { get; set; } = string.Empty;
+
     // This is set up by the game itself and will display in the lobby
     public int RoundOfDeath { get; set; } = -1;
 

--- a/TownOfUs/Modifiers/DeathHandlerModifier.cs
+++ b/TownOfUs/Modifiers/DeathHandlerModifier.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using MiraAPI.Modifiers;
 using Reactor.Networking.Attributes;
+using Reactor.Networking.Rpc;
 using Reactor.Utilities;
 using TownOfUs.Events;
 using UnityEngine;
@@ -69,6 +70,17 @@ public sealed class DeathHandlerModifier : BaseModifier
         var localizedCod = TouLocale.Get(causeOfDeath).Contains("STRMISS") ? "null" : TouLocale.Get(causeOfDeath);
         var localizedKilledBy = (TouLocale.GetParsed(killedByString).Contains("STRMISS") || killedBy == null) ? "null" : TouLocale.GetParsed(killedByString).Replace("<player>", killedBy.Data.PlayerName);
         UpdateDeathHandler(player, localizedCod, roundOfDeath, diedThisRound, localizedKilledBy, lockInfo);
+    }
+
+    [MethodRpc((uint)TownOfUsRpc.MisguessSummary, LocalHandling = RpcLocalHandling.After)]
+    public static void RpcSetMisguessSummary(PlayerControl player, byte victimId, string roleText)
+    {
+        var name = GameData.Instance?.GetPlayerById(victimId)?.Object?.Data?.PlayerName ?? "?";
+        var summary = TouLocale.GetParsed("MisguessSummary")
+            .Replace("<player>", name)
+            .Replace("<role>", roleText);
+
+        Coroutines.Start(CoSetExtended(player, summary));
     }
 
     public static void UpdateDeathHandler(PlayerControl player, string causeOfDeath = "null", int roundOfDeath = -1,
@@ -192,6 +204,21 @@ public sealed class DeathHandlerModifier : BaseModifier
         }
 
         IsAltCoroutineRunning = false;
+    }
+
+    private static IEnumerator CoSetExtended(PlayerControl player, string summary)
+    {
+        var timeout = 5f;
+        while (timeout > 0f && player && !player.HasModifier<DeathHandlerModifier>())
+        {
+            timeout -= Time.deltaTime;
+            yield return null;
+        }
+
+        if (player && player.TryGetModifier<DeathHandlerModifier>(out var deathHandler))
+        {
+            deathHandler.ExtendedCauseOfDeath = summary;
+        }
     }
 }
 

--- a/TownOfUs/Modifiers/Game/AssassinModifier.cs
+++ b/TownOfUs/Modifiers/Game/AssassinModifier.cs
@@ -51,6 +51,8 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
     // YES this is scuffed, a better solution will be used at a later time
     public override bool ShowInFreeplay => false;
     public string LastGuessedItem { get; set; }
+    public uint LastGuessedItemId { get; set; }
+    public bool LastGuessedIsRole { get; set; }
     public PlayerControl? LastAttemptedVictim { get; set; }
 
     public override bool HideOnUi => HasDoubleShot;
@@ -196,10 +198,12 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
 
             LastAttemptedVictim = player;
             LastGuessedItem = $"{role.TeamColor.ToTextColor()}{role.GetRoleName()}</color>";
+            LastGuessedIsRole = true;
+            LastGuessedItemId = (ushort)role.Role;
 
             if (ClickHandler(victim) && victim == Player)
             {
-                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, LastGuessedItem);
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, LastGuessedItemId, LastGuessedIsRole);
             }
         }
 
@@ -211,10 +215,12 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
             LastAttemptedVictim = player;
             LastGuessedItem =
                 $"{MiscUtils.GetRoleColour(modifier.ModifierName.Replace(" ", string.Empty)).ToTextColor()}{modifier.ModifierName}</color>";
+            LastGuessedIsRole = false;
+            LastGuessedItemId = modifier.TypeId;
 
             if (ClickHandler(victim) && victim == Player)
             {
-                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, LastGuessedItem);
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, LastGuessedItemId, LastGuessedIsRole);
             }
         }
 

--- a/TownOfUs/Modifiers/Game/AssassinModifier.cs
+++ b/TownOfUs/Modifiers/Game/AssassinModifier.cs
@@ -1,10 +1,13 @@
-﻿using HarmonyLib;
+﻿using System.Collections;
+using HarmonyLib;
 using MiraAPI.GameOptions;
 using MiraAPI.Modifiers;
 using MiraAPI.Networking;
 using MiraAPI.Roles;
 using MiraAPI.Utilities;
 using MiraAPI.Utilities.Assets;
+using Reactor.Networking.Attributes;
+using Reactor.Networking.Rpc;
 using Reactor.Utilities;
 using TownOfUs.Modifiers.Crewmate;
 using TownOfUs.Modifiers.HnsGame;
@@ -194,9 +197,13 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
             }
             var victim = pickVictim ? player : Player;
 
-            ClickHandler(victim);
             LastAttemptedVictim = player;
             LastGuessedItem = $"{role.TeamColor.ToTextColor()}{role.GetRoleName()}</color>";
+
+            if (ClickHandler(victim) && victim == Player)
+            {
+                RpcAssassinMisguessSummary(Player, player.PlayerId, LastGuessedItem);
+            }
         }
 
         void ClickModifierHandle(BaseModifier modifier)
@@ -204,17 +211,21 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
             var pickVictim = player.HasModifier(modifier.TypeId);
             var victim = pickVictim ? player : Player;
 
-            ClickHandler(victim);
             LastAttemptedVictim = player;
             LastGuessedItem =
                 $"{MiscUtils.GetRoleColour(modifier.ModifierName.Replace(" ", string.Empty)).ToTextColor()}{modifier.ModifierName}</color>";
+
+            if (ClickHandler(victim) && victim == Player)
+            {
+                RpcAssassinMisguessSummary(Player, player.PlayerId, LastGuessedItem);
+            }
         }
 
-        void ClickHandler(PlayerControl victim)
+        bool ClickHandler(PlayerControl victim)
         {
             if (victim.HasDied() || Player.HasDied())
             {
-                return;
+                return false;
             }
 
             if (victim != Player && victim.TryGetModifier<OracleBlessedModifier>(out var oracleMod))
@@ -227,7 +238,7 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
                 LastGuessedItem = string.Empty;
                 LastAttemptedVictim = null;
 
-                return;
+                return false;
             }
 
             if (victim == Player && Player.TryGetModifier<DoubleShotModifier>(out var modifier) && !modifier.Used)
@@ -246,7 +257,7 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
                 LastGuessedItem = string.Empty;
                 LastAttemptedVictim = null;
 
-                return;
+                return false;
             }
             Player.RpcSpecialMurder(victim, MeetingCheck.ForMeeting, true, true, createDeadBody: false, teleportMurderer: false,
                 showKillAnim: false,
@@ -268,6 +279,33 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
             }
 
             shapeMenu.Close();
+            return true;
+        }
+    }
+
+    [MethodRpc((uint)TownOfUsRpc.AssassinMisguessSummary, LocalHandling = RpcLocalHandling.After)]
+    public static void RpcAssassinMisguessSummary(PlayerControl assassin, byte victimId, string roleText)
+    {
+        var name = GameData.Instance?.GetPlayerById(victimId)?.Object?.Data?.PlayerName ?? "?";
+        var summary = TouLocale.GetParsed("TouModifierAssassinMisguessSummary")
+            .Replace("<player>", name)
+            .Replace("<role>", roleText);
+
+        Coroutines.Start(CoSetExtended(assassin, summary));
+    }
+
+    private static IEnumerator CoSetExtended(PlayerControl player, string summary)
+    {
+        var timeout = 5f;
+        while (timeout > 0f && player && !player.HasModifier<DeathHandlerModifier>())
+        {
+            timeout -= Time.deltaTime;
+            yield return null;
+        }
+
+        if (player && player.TryGetModifier<DeathHandlerModifier>(out var deathHandler))
+        {
+            deathHandler.ExtendedCauseOfDeath = summary;
         }
     }
 

--- a/TownOfUs/Modifiers/Game/AssassinModifier.cs
+++ b/TownOfUs/Modifiers/Game/AssassinModifier.cs
@@ -1,13 +1,10 @@
-﻿using System.Collections;
-using HarmonyLib;
+﻿using HarmonyLib;
 using MiraAPI.GameOptions;
 using MiraAPI.Modifiers;
 using MiraAPI.Networking;
 using MiraAPI.Roles;
 using MiraAPI.Utilities;
 using MiraAPI.Utilities.Assets;
-using Reactor.Networking.Attributes;
-using Reactor.Networking.Rpc;
 using Reactor.Utilities;
 using TownOfUs.Modifiers.Crewmate;
 using TownOfUs.Modifiers.HnsGame;
@@ -202,7 +199,7 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
 
             if (ClickHandler(victim) && victim == Player)
             {
-                RpcAssassinMisguessSummary(Player, player.PlayerId, LastGuessedItem);
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, LastGuessedItem);
             }
         }
 
@@ -217,7 +214,7 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
 
             if (ClickHandler(victim) && victim == Player)
             {
-                RpcAssassinMisguessSummary(Player, player.PlayerId, LastGuessedItem);
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, LastGuessedItem);
             }
         }
 
@@ -280,32 +277,6 @@ public class AssassinModifier : TouGameModifier, IWikiDiscoverable
 
             shapeMenu.Close();
             return true;
-        }
-    }
-
-    [MethodRpc((uint)TownOfUsRpc.AssassinMisguessSummary, LocalHandling = RpcLocalHandling.After)]
-    public static void RpcAssassinMisguessSummary(PlayerControl assassin, byte victimId, string roleText)
-    {
-        var name = GameData.Instance?.GetPlayerById(victimId)?.Object?.Data?.PlayerName ?? "?";
-        var summary = TouLocale.GetParsed("TouModifierAssassinMisguessSummary")
-            .Replace("<player>", name)
-            .Replace("<role>", roleText);
-
-        Coroutines.Start(CoSetExtended(assassin, summary));
-    }
-
-    private static IEnumerator CoSetExtended(PlayerControl player, string summary)
-    {
-        var timeout = 5f;
-        while (timeout > 0f && player && !player.HasModifier<DeathHandlerModifier>())
-        {
-            timeout -= Time.deltaTime;
-            yield return null;
-        }
-
-        if (player && player.TryGetModifier<DeathHandlerModifier>(out var deathHandler))
-        {
-            deathHandler.ExtendedCauseOfDeath = summary;
         }
     }
 

--- a/TownOfUs/Patches/EndGamePatches.cs
+++ b/TownOfUs/Patches/EndGamePatches.cs
@@ -255,13 +255,18 @@ public static class EndGamePatches
 
             if (playerControl.TryGetModifier<DeathHandlerModifier>(out var deathHandler))
             {
+                var hasExtendedCauseOfDeath = !string.IsNullOrEmpty(deathHandler.ExtendedCauseOfDeath);
+                var causeOfDeath = hasExtendedCauseOfDeath
+                    ? deathHandler.ExtendedCauseOfDeath
+                    : deathHandler.CauseOfDeath;
+
                 playerRoleString.Append(TownOfUsPlugin.Culture,
-                    $" | {Color.yellow.ToTextColor()}{deathHandler.CauseOfDeath}</color>");
+                    $" | {Color.yellow.ToTextColor()}{causeOfDeath}</color>");
                 playerRoleStringShort.Append(TownOfUsPlugin.Culture,
                     $" | {Color.yellow.ToTextColor()}{deathHandler.CauseOfDeath}</color>");
                 summaryCod.Append(TownOfUsPlugin.Culture,
-                    $"{Color.yellow.ToTextColor()}{deathHandler.CauseOfDeath}</color>");
-                if (deathHandler.KilledBy != string.Empty)
+                    $"{Color.yellow.ToTextColor()}{causeOfDeath}</color>");
+                if (!hasExtendedCauseOfDeath && deathHandler.KilledBy != string.Empty)
                 {
                     playerRoleString.Append(TownOfUsPlugin.Culture,
                         $" {deathHandler.KilledBy}");

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2364,6 +2364,7 @@
   <string name="TouModifierAssassinIntroBlurb">Guess players in the meeting.</string>
   <string name="TouModifierAssassinWikiDescription">You have the ability to guess a player in a meeting.</string>
   <string name="TouModifierAssassinTabDescription">Guess players out of the meeting.</string>
+  <string name="TouModifierAssassinMisguessSummary">Misguessed \%player\% as \%role\%</string>
   <!-- Assassin Options -->
   <string name="TouOptionAssassinNeutAssassinTitle">Neut Assassins: </string>
   <string name="TouOptionAssassinImpAssassinTitle">Imp Assassins: </string>

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2364,7 +2364,7 @@
   <string name="TouModifierAssassinIntroBlurb">Guess players in the meeting.</string>
   <string name="TouModifierAssassinWikiDescription">You have the ability to guess a player in a meeting.</string>
   <string name="TouModifierAssassinTabDescription">Guess players out of the meeting.</string>
-  <string name="TouModifierAssassinMisguessSummary">Misguessed \%player\% as \%role\%</string>
+  <string name="MisguessSummary">Misguessed \%player\% as \%role\%</string>
   <!-- Assassin Options -->
   <string name="TouOptionAssassinNeutAssassinTitle">Neut Assassins: </string>
   <string name="TouOptionAssassinImpAssassinTitle">Imp Assassins: </string>

--- a/TownOfUs/Resources/Locale/nl_NL.xml
+++ b/TownOfUs/Resources/Locale/nl_NL.xml
@@ -524,5 +524,5 @@
   <string name="PiPSizeLarge">Groot</string>
   <string name="PlayerColorDarker">Donkerder</string>
   <string name="PlayerColorLighter">Lichter</string>
-  <string name="TouModifierAssassinMisguessSummary">Heeft \%player\% verkeerd geraden als \%role\%</string>
+  <string name="MisguessSummary">Heeft \%player\% verkeerd geraden als \%role\%</string>
 </resources>

--- a/TownOfUs/Resources/Locale/nl_NL.xml
+++ b/TownOfUs/Resources/Locale/nl_NL.xml
@@ -524,4 +524,5 @@
   <string name="PiPSizeLarge">Groot</string>
   <string name="PlayerColorDarker">Donkerder</string>
   <string name="PlayerColorLighter">Lichter</string>
+  <string name="TouModifierAssassinMisguessSummary">Heeft \%player\% verkeerd geraden als \%role\%</string>
 </resources>

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateKilling/VigilanteRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateKilling/VigilanteRole.cs
@@ -8,6 +8,7 @@ using MiraAPI.Patches.Stubs;
 using MiraAPI.Roles;
 using MiraAPI.Utilities;
 using Reactor.Utilities;
+using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Crewmate;
 using TownOfUs.Modifiers.Game;
 using TownOfUs.Modifiers.HnsGame;
@@ -169,19 +170,28 @@ public sealed class VigilanteRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCre
                 }
             }
             var victim = pickVictim ? player : Player;
+            var roleText = $"{role.TeamColor.ToTextColor()}{role.GetRoleName()}</color>";
 
-            ClickHandler(victim);
+            if (ClickHandler(victim) && victim == Player)
+            {
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, roleText);
+            }
         }
 
         void ClickModifierHandle(BaseModifier modifier)
         {
             var pickVictim = player.HasModifier(modifier.TypeId);
             var victim = pickVictim ? player : Player;
+            var modifierText =
+                $"{MiscUtils.GetRoleColour(modifier.ModifierName.Replace(" ", string.Empty)).ToTextColor()}{modifier.ModifierName}</color>";
 
-            ClickHandler(victim);
+            if (ClickHandler(victim) && victim == Player)
+            {
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, modifierText);
+            }
         }
 
-        void ClickHandler(PlayerControl victim)
+        bool ClickHandler(PlayerControl victim)
         {
             if (!OptionGroupSingleton<VigilanteOptions>.Instance.VigilanteMultiKill || MaxKills == 0 ||
                 victim == Player)
@@ -197,7 +207,7 @@ public sealed class VigilanteRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCre
 
                 shapeMenu.Close();
 
-                return;
+                return false;
             }
 
             if (victim == Player && SafeShotsLeft != 0)
@@ -213,7 +223,7 @@ public sealed class VigilanteRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCre
 
                 shapeMenu.Close();
 
-                return;
+                return false;
             }
             Player.RpcSpecialMurder(victim, MeetingCheck.ForMeeting, true, true, createDeadBody: false, teleportMurderer: false,
                 showKillAnim: false,
@@ -226,6 +236,7 @@ public sealed class VigilanteRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCre
             }
 
             shapeMenu.Close();
+            return true;
         }
     }
 

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateKilling/VigilanteRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateKilling/VigilanteRole.cs
@@ -170,11 +170,10 @@ public sealed class VigilanteRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCre
                 }
             }
             var victim = pickVictim ? player : Player;
-            var roleText = $"{role.TeamColor.ToTextColor()}{role.GetRoleName()}</color>";
 
             if (ClickHandler(victim) && victim == Player)
             {
-                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, roleText);
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, (ushort)role.Role, true);
             }
         }
 
@@ -182,12 +181,10 @@ public sealed class VigilanteRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCre
         {
             var pickVictim = player.HasModifier(modifier.TypeId);
             var victim = pickVictim ? player : Player;
-            var modifierText =
-                $"{MiscUtils.GetRoleColour(modifier.ModifierName.Replace(" ", string.Empty)).ToTextColor()}{modifier.ModifierName}</color>";
 
             if (ClickHandler(victim) && victim == Player)
             {
-                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, modifierText);
+                DeathHandlerModifier.RpcSetMisguessSummary(Player, player.PlayerId, modifier.TypeId, false);
             }
         }
 

--- a/TownOfUs/TownOfUsRpc.cs
+++ b/TownOfUs/TownOfUsRpc.cs
@@ -137,7 +137,7 @@ public enum TownOfUsRpc : uint
     OfficerMisfire,
     OfficerSyncBullets,
     SetUpCrewpostor,
-    AssassinMisguessSummary,
+    MisguessSummary,
 }
 
 internal enum TownOfUsInternalRpc : uint

--- a/TownOfUs/TownOfUsRpc.cs
+++ b/TownOfUs/TownOfUsRpc.cs
@@ -137,6 +137,7 @@ public enum TownOfUsRpc : uint
     OfficerMisfire,
     OfficerSyncBullets,
     SetUpCrewpostor,
+    AssassinMisguessSummary,
 }
 
 internal enum TownOfUsInternalRpc : uint


### PR DESCRIPTION
<img width="1344" height="553" alt="Screenshot (842)" src="https://github.com/user-attachments/assets/e5e6d67c-5a2b-4127-892c-3c6b3618de5a" />

# Added:

More clarity for end game summaries to who misguessed which role, leading to the CoD: Misguess.
This works fine with DoubleShot and Oracle

@AtonyGit 