### PR TITLE
fix(ghosts): ghosts cannot see the roles of players in cams

### DIFF
--- a/TownOfUs/Patches/HudManagerPatches.cs
+++ b/TownOfUs/Patches/HudManagerPatches.cs
@@ -315,9 +315,12 @@ public static class HudManagerPatches
             return mod?.ExtraNameText ?? string.Empty;
         }
 
+        var hauntMode = (GhostModeInGame)OptionGroupSingleton<PostmortemOptions>.Instance.DeadCanHaunt.Value;
+        var shouldSeeHauntInfo = hauntMode is GhostModeInGame.Always || (hauntMode is GhostModeInGame.DisabledUponDeath && DeathHandlerModifier.IsFullyDead(PlayerControl.LocalPlayer));
+        
         var colorPlayerNames = LocalSettingsTabSingleton<TownOfUsLocalSettings>.Instance.ColorPlayerNameToggle.Value;
         var localDead = PlayerControl.LocalPlayer.HasDied();
-        var localGhost = DeathHandlerModifier.IsFullyDead(PlayerControl.LocalPlayer) && genOpt.TheDeadKnow;
+        var localGhost = localDead && genOpt.TheDeadKnow && shouldSeeHauntInfo;
         var localImp = PlayerControl.LocalPlayer.IsImpostorAligned() &&
                        genOpt is
                            { ImpsKnowRoles.Value: true, FFAImpostorMode: false };

--- a/TownOfUs/Patches/HudManagerPatches.cs
+++ b/TownOfUs/Patches/HudManagerPatches.cs
@@ -317,7 +317,7 @@ public static class HudManagerPatches
 
         var colorPlayerNames = LocalSettingsTabSingleton<TownOfUsLocalSettings>.Instance.ColorPlayerNameToggle.Value;
         var localDead = PlayerControl.LocalPlayer.HasDied();
-        var localGhost = localDead && genOpt.TheDeadKnow;
+        var localGhost = DeathHandlerModifier.IsFullyDead(PlayerControl.LocalPlayer) && genOpt.TheDeadKnow;
         var localImp = PlayerControl.LocalPlayer.IsImpostorAligned() &&
                        genOpt is
                            { ImpsKnowRoles.Value: true, FFAImpostorMode: false };


### PR DESCRIPTION
this PR has two commits:
1. one basic one to check `isFullyDead()` and
2. one to respect the `DeadCanHaunt` option (roles don't show if it's set `Disabled`, or if it's set to `DisabledUponDeath` and `isFullyDead()` is false.

I separated the two because I wanted to give the choice to a respected maintainer/contributor that knows what TOUM gameplay should be like (probably AtonyGit from what I can see)