### PR TITLE
Fix plumber block

### DIFF
--- a/TownOfUs/Events/Crewmate/PlumberEvents.cs
+++ b/TownOfUs/Events/Crewmate/PlumberEvents.cs
@@ -9,7 +9,6 @@ using MiraAPI.Roles;
 using TownOfUs.Buttons.Crewmate;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
-using UnityEngine;
 
 namespace TownOfUs.Events.Crewmate;
 
@@ -52,7 +51,7 @@ public static class PlumberEvents
             return;
         }
 
-        if (PlumberRole.VentBlockSet.Contains(vent.Id) || PlumberRole.VentFlushSet.Contains(vent.Id))
+        if (PlumberRole.VentsBlocked.ContainsKey(vent.Id) || PlumberRole.VentFlushSet.Contains(vent.Id))
         {
             @event.Cancel();
         }
@@ -89,8 +88,5 @@ public static class PlumberEvents
         {
             plumber.SetupBarricades();
         }
-
-        PlumberRole.VentBlockSet.Clear();
-        PlumberRole.VentBlockSet = PlumberRole.VentsBlocked.Keys.ToHashSet();
     }
 }

--- a/TownOfUs/Events/Crewmate/PlumberEvents.cs
+++ b/TownOfUs/Events/Crewmate/PlumberEvents.cs
@@ -63,40 +63,25 @@ public static class PlumberEvents
     {
         if ((int)OptionGroupSingleton<PlumberOptions>.Instance.BarricadeRoundDuration > 0)
         {
-            var barricadeList = new List<KeyValuePair<GameObject, int>>();
-            if (PlumberRole.Barricades.Count > 0)
+            var unblockedVents = new HashSet<int>();
+            foreach (var (ventId, rounds) in PlumberRole.VentsBlocked)
             {
-                foreach (var barricadePair in PlumberRole.Barricades)
+                if (rounds == 1)
                 {
-                    if (barricadePair.Value == 1)
-                    {
-                        UnityEngine.Object.Destroy(barricadePair.Key);
-                        continue;
-                    }
-
-                    barricadeList.Add(new(barricadePair.Key, barricadePair.Value - 1));
+                    unblockedVents.Add(ventId);
+                    PlumberRole.Barricades.Remove(ventId, out var barricade);
+                    UnityEngine.Object.Destroy(barricade);
+                    continue;
                 }
+
+                PlumberRole.VentsBlocked[ventId] -= 1;
             }
 
-            PlumberRole.Barricades.Clear();
-            PlumberRole.Barricades = barricadeList;
-
-            var ventList = new List<KeyValuePair<int, int>>();
-            if (PlumberRole.VentsBlocked.Count > 0)
+            foreach (var vent in unblockedVents)
             {
-                foreach (var ventPair in PlumberRole.VentsBlocked)
-                {
-                    if (ventPair.Value == 1)
-                    {
-                        continue;
-                    }
-
-                    ventList.Add(new(ventPair.Key, ventPair.Value - 1));
-                }
+                PlumberRole.VentsBlocked.Remove(vent);
             }
 
-            PlumberRole.VentsBlocked.Clear();
-            PlumberRole.VentsBlocked = ventList;
             PlumberRole.VentFlushSet.Clear();
         }
 
@@ -106,6 +91,6 @@ public static class PlumberEvents
         }
 
         PlumberRole.VentBlockSet.Clear();
-        PlumberRole.VentBlockSet = PlumberRole.VentsBlocked.Select(x => x.Key).ToHashSet();
+        PlumberRole.VentBlockSet = PlumberRole.VentsBlocked.Keys.ToHashSet();
     }
 }

--- a/TownOfUs/Events/Crewmate/PlumberEvents.cs
+++ b/TownOfUs/Events/Crewmate/PlumberEvents.cs
@@ -97,8 +97,6 @@ public static class PlumberEvents
 
             PlumberRole.VentsBlocked.Clear();
             PlumberRole.VentsBlocked = ventList;
-            PlumberRole.VentBlockList.Clear();
-            PlumberRole.VentBlockList = ventList.Select(x => x.Key).ToList();
             PlumberRole.VentFlushList.Clear();
         }
 
@@ -106,5 +104,8 @@ public static class PlumberEvents
         {
             plumber.SetupBarricades();
         }
+
+        PlumberRole.VentBlockList.Clear();
+        PlumberRole.VentBlockList = PlumberRole.VentsBlocked.Select(x => x.Key).ToList();
     }
 }

--- a/TownOfUs/Events/Crewmate/PlumberEvents.cs
+++ b/TownOfUs/Events/Crewmate/PlumberEvents.cs
@@ -52,7 +52,7 @@ public static class PlumberEvents
             return;
         }
 
-        if (PlumberRole.VentBlockList.Contains(vent.Id) || PlumberRole.VentFlushList.Contains(vent.Id))
+        if (PlumberRole.VentBlockSet.Contains(vent.Id) || PlumberRole.VentFlushSet.Contains(vent.Id))
         {
             @event.Cancel();
         }
@@ -97,7 +97,7 @@ public static class PlumberEvents
 
             PlumberRole.VentsBlocked.Clear();
             PlumberRole.VentsBlocked = ventList;
-            PlumberRole.VentFlushList.Clear();
+            PlumberRole.VentFlushSet.Clear();
         }
 
         foreach (var plumber in CustomRoleUtils.GetActiveRolesOfType<PlumberRole>())
@@ -105,7 +105,7 @@ public static class PlumberEvents
             plumber.SetupBarricades();
         }
 
-        PlumberRole.VentBlockList.Clear();
-        PlumberRole.VentBlockList = PlumberRole.VentsBlocked.Select(x => x.Key).ToList();
+        PlumberRole.VentBlockSet.Clear();
+        PlumberRole.VentBlockSet = PlumberRole.VentsBlocked.Select(x => x.Key).ToHashSet();
     }
 }

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/PlumberRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/PlumberRole.cs
@@ -26,7 +26,6 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 
     // Blocked vent, remaining rounds
     [HideFromIl2Cpp] public static Dictionary<int, int> VentsBlocked { get; set; } = [];
-    [HideFromIl2Cpp] public static HashSet<int> VentBlockSet { get; set; } = [];
     [HideFromIl2Cpp] public static HashSet<int> VentFlushSet { get; set; } = [];
 
 
@@ -183,7 +182,6 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 
         VentsBlocked.Clear();
         Barricades.Clear();
-        VentBlockSet.Clear();
         VentFlushSet.Clear();
     }
 

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/PlumberRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/PlumberRole.cs
@@ -25,13 +25,13 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
     [HideFromIl2Cpp] public HashSet<int> FutureBlocks { get; set; } = [];
 
     // Blocked vent, remaining rounds
-    [HideFromIl2Cpp] public static List<KeyValuePair<int, int>> VentsBlocked { get; set; } = [];
+    [HideFromIl2Cpp] public static Dictionary<int, int> VentsBlocked { get; set; } = [];
     [HideFromIl2Cpp] public static HashSet<int> VentBlockSet { get; set; } = [];
     [HideFromIl2Cpp] public static HashSet<int> VentFlushSet { get; set; } = [];
 
 
-    // Barricade object, remaining rounds
-    [HideFromIl2Cpp] public static List<KeyValuePair<GameObject, int>> Barricades { get; set; } = [];
+    // Blocked vent, Barricade object
+    [HideFromIl2Cpp] public static Dictionary<int, GameObject> Barricades { get; set; } = [];
 
     public DoomableType DoomHintType => DoomableType.Trickster;
     public string LocaleKey => "Plumber";
@@ -96,16 +96,16 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 
             if (VentsBlocked.Count > 0)
             {
-                foreach (var ventPair in VentsBlocked)
+                foreach (var (ventId, rounds) in VentsBlocked)
                 {
-                    var vent = Helpers.GetVentById(ventPair.Key);
+                    var vent = Helpers.GetVentById(ventId);
                     if (vent == null)
                     {
                         continue;
                     }
 
                     var ventLabel = TouLocale.GetParsed("TouRolePlumberVentLabelTabText").Replace("<roomName>", MiscUtils.GetRoomName(vent.transform.position));
-                    var text2 = duration == 0 ? string.Empty : $": {TouLocale.GetParsed("TouRolePlumberVentRoundsTabText").Replace("<roundsRemaining>", ventPair.Value.ToString(TownOfUsPlugin.Culture))}";
+                    var text2 = duration == 0 ? string.Empty : $": {TouLocale.GetParsed("TouRolePlumberVentRoundsTabText").Replace("<roundsRemaining>", rounds.ToString(TownOfUsPlugin.Culture))}";
                     stringB.Append(TownOfUsPlugin.Culture,
                         $"\n{ventLabel}{text2}");
                 }
@@ -154,17 +154,14 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 
     public void Clear()
     {
-        if (Barricades.Count > 0)
+        foreach (var barricade in Barricades.Values)
         {
-            foreach (var barricade in Barricades.Select(x => x.Key))
+            if (barricade == null)
             {
-                if (barricade == null)
-                {
-                    continue;
-                }
-
-                Destroy(barricade);
+                continue;
             }
+
+            Destroy(barricade);
         }
 
         FutureBlocks.Clear();
@@ -174,17 +171,14 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 
     public static void ClearAll()
     {
-        if (Barricades.Count > 0)
+        foreach (var barricade in Barricades.Values)
         {
-            foreach (var barricade in Barricades.Select(x => x.Key))
+            if (barricade == null)
             {
-                if (barricade == null)
-                {
-                    continue;
-                }
-
-                Destroy(barricade);
+                continue;
             }
+
+            Destroy(barricade);
         }
 
         VentsBlocked.Clear();
@@ -197,7 +191,12 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
     {
         foreach (var ventId in FutureBlocks)
         {
-            VentsBlocked.Add(new(ventId, (int)OptionGroupSingleton<PlumberOptions>.Instance.BarricadeRoundDuration));
+            var alreadySet = VentsBlocked.ContainsKey(ventId);
+            VentsBlocked[ventId] = (int)OptionGroupSingleton<PlumberOptions>.Instance.BarricadeRoundDuration;
+            if (alreadySet)
+            {
+                continue;
+            }
 
             GameObject barricade = new("Barricade");
 
@@ -274,7 +273,7 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
                 }
             }
 
-            Barricades.Add(new(barricade, (int)OptionGroupSingleton<PlumberOptions>.Instance.BarricadeRoundDuration));
+            Barricades.Add(ventId, barricade);
         }
 
         FutureBlocks.Clear();

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/PlumberRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/PlumberRole.cs
@@ -22,12 +22,12 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 {
     public override bool IsAffectedByComms => false;
 
-    [HideFromIl2Cpp] public List<int> FutureBlocks { get; set; } = [];
+    [HideFromIl2Cpp] public HashSet<int> FutureBlocks { get; set; } = [];
 
     // Blocked vent, remaining rounds
     [HideFromIl2Cpp] public static List<KeyValuePair<int, int>> VentsBlocked { get; set; } = [];
-    [HideFromIl2Cpp] public static List<int> VentBlockList { get; set; } = [];
-    [HideFromIl2Cpp] public static List<int> VentFlushList { get; set; } = [];
+    [HideFromIl2Cpp] public static HashSet<int> VentBlockSet { get; set; } = [];
+    [HideFromIl2Cpp] public static HashSet<int> VentFlushSet { get; set; } = [];
 
 
     // Barricade object, remaining rounds
@@ -189,8 +189,8 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
 
         VentsBlocked.Clear();
         Barricades.Clear();
-        VentBlockList.Clear();
-        VentFlushList.Clear();
+        VentBlockSet.Clear();
+        VentFlushSet.Clear();
     }
 
     public void SetupBarricades()
@@ -300,11 +300,11 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
     public static IEnumerator SetupFlush(int id)
     {
         var delay = OptionGroupSingleton<PlumberOptions>.Instance.FlushDuration;
-        VentFlushList.Add(id);
+        VentFlushSet.Add(id);
 
         yield return new WaitForSeconds(delay);
 
-        VentFlushList.Remove(id);
+        VentFlushSet.Remove(id);
     }
 
     [MethodRpc((uint)TownOfUsRpc.PlumberFlush)]
@@ -371,10 +371,7 @@ public sealed class PlumberRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
             return;
         }
 
-        if (!plumber.FutureBlocks.Contains(ventId))
-        {
-            plumber.FutureBlocks.Add(ventId);
-        }
+        plumber.FutureBlocks.Add(ventId);
 
         var touAbilityEvent = new TouAbilityEvent(AbilityType.PlumberBlock, player, Helpers.GetVentById(ventId));
         MiraEventManager.InvokeEvent(touAbilityEvent);


### PR DESCRIPTION
This PR tackles some errors in the way Plumber tries to keep track of Vents in order to block them, such that the first round would not actually mark the vent as blocked, even if the barricade GameObject was placed and was visible. This PR changes the data structures they're being tracked in to HashSets and Dictionaries for more intuitive logic, as well as preventing duplicates on either set.