### PR TITLE
Engineer Vent Button + Medic Meeting + Glitch Hacked fix

### DIFF
--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/MediumMediateButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/MediumMediateButton.cs
@@ -4,7 +4,6 @@ using MiraAPI.Utilities;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Crewmate;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
 using UnityEngine;
@@ -99,8 +98,7 @@ public sealed class MediumMediateButton : TownOfUsRoleButton<MediumRole>, ILegac
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SpyAdminTableRoleButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SpyAdminTableRoleButton.cs
@@ -3,7 +3,6 @@ using MiraAPI.Hud;
 using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
 using UnityEngine;
@@ -102,8 +101,7 @@ public sealed class SpyAdminTableRoleButton : TownOfUsRoleButton<SpyRole>
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmatePower/MonarchKnightButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmatePower/MonarchKnightButton.cs
@@ -5,7 +5,6 @@ using MiraAPI.Utilities.Assets;
 using Reactor.Utilities;
 using TownOfUs.Events;
 using TownOfUs.Modifiers;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Modules;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
@@ -81,8 +80,7 @@ public sealed class MonarchKnightButton : TownOfUsRoleButton<MonarchRole, Player
 
         try
         {
-            if (!CanClick() || PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() ||
-                PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+            if (!CanClick())
             {
                 return;
             }

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/Engineer2FixButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/Engineer2FixButton.cs
@@ -1,9 +1,6 @@
 ﻿using MiraAPI.GameOptions;
-using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using Reactor.Utilities.Extensions;
-using TownOfUs.Modifiers;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
 using UnityEngine;
@@ -29,8 +26,7 @@ public sealed class EngineerFixButton : TownOfUsRoleButton<EngineerTouRole>, ILe
 
     public override void ClickHandler()
     {
-        if (!CanClick() || PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() ||
-            PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (!CanClick())
         {
             return;
         }

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/SentryPortableCameraButtonBase.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/SentryPortableCameraButtonBase.cs
@@ -4,7 +4,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.PluginLoading;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Patches.PrefabChanging;
 using TownOfUs.Roles.Crewmate;
@@ -89,8 +88,8 @@ public abstract class SentryPortableCameraButtonBase : TownOfUsRoleButton<Sentry
 
     public override void ClickHandler()
     {
-        if (!CanClick() || PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() ||
-            PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities) || !MiscUtils.CanUseUtility(GameUtility.Cams, true))
+        if (!CanClick() || PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities) ||
+            !MiscUtils.CanUseUtility(GameUtility.Cams, true))
         {
             return;
         }
@@ -280,8 +279,7 @@ public abstract class SentryPortableCameraButtonBase : TownOfUsRoleButton<Sentry
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Classic/Impostor/ImpostorConcealing/MorphlingMorphButton.cs
+++ b/TownOfUs/Buttons/Classic/Impostor/ImpostorConcealing/MorphlingMorphButton.cs
@@ -3,7 +3,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Impostor;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Impostor;
 using TownOfUs.Roles.Impostor;
 using UnityEngine;
@@ -59,8 +58,7 @@ public sealed class MorphlingMorphButton : TownOfUsRoleButton<MorphlingRole>, IA
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Classic/Impostor/ImpostorConcealing/SwooperSwoopButton.cs
+++ b/TownOfUs/Buttons/Classic/Impostor/ImpostorConcealing/SwooperSwoopButton.cs
@@ -3,7 +3,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Impostor;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Impostor;
 using TownOfUs.Roles.Impostor;
 using UnityEngine;
@@ -71,8 +70,7 @@ public sealed class SwooperSwoopButton : TownOfUsRoleButton<SwooperRole>, IAfter
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Classic/Impostor/ImpostorKilling/ParasiteOvertakeButton.cs
+++ b/TownOfUs/Buttons/Classic/Impostor/ImpostorKilling/ParasiteOvertakeButton.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using TownOfUs.Interfaces;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Crewmate;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Modules;
 using TownOfUs.Modules.ControlSystem;
 using TownOfUs.Networking;
@@ -157,8 +156,7 @@ public sealed class ParasiteOvertakeButton : TownOfUsKillRoleButton<ParasiteRole
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() ||
-            PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Classic/Impostor/ImpostorPower/HerbalistAbilityHerbButton.cs
+++ b/TownOfUs/Buttons/Classic/Impostor/ImpostorPower/HerbalistAbilityHerbButton.cs
@@ -3,9 +3,7 @@ using MiraAPI.GameOptions;
 using MiraAPI.Modifiers;
 using MiraAPI.Utilities;
 using MiraAPI.Utilities.Assets;
-using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Impostor.Herbalist;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options;
 using TownOfUs.Options.Roles.Impostor;
 using TownOfUs.Roles.Impostor;
@@ -48,8 +46,7 @@ public sealed class HerbalistAbilityHerbButton : TownOfUsRoleButton<HerbalistRol
 
     public override void ClickHandler()
     {
-        if (CanClick() && !PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() &&
-            !PlayerControl.LocalPlayer.HasModifier<DisabledModifier>())
+        if (CanClick())
         {
             if (CurrentHerbsLimited)
             {

--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/GlitchMimicButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/GlitchMimicButton.cs
@@ -154,8 +154,7 @@ public sealed class GlitchMimicButton : TownOfUsRoleButton<GlitchRole>, IAfterma
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/HideAndSeek/Hider/ChameleonSwoopButton.cs
+++ b/TownOfUs/Buttons/HideAndSeek/Hider/ChameleonSwoopButton.cs
@@ -3,7 +3,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.HnsCrewmate;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.HnsCrewmate;
 using TownOfUs.Roles.HideAndSeek.Hider;
 using UnityEngine;
@@ -52,8 +51,7 @@ public sealed class ChameleonSwoopButton : TownOfUsRoleButton<HnsChameleonRole>
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Modifiers/ScientistButton.cs
+++ b/TownOfUs/Buttons/Modifiers/ScientistButton.cs
@@ -5,7 +5,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Game.Crewmate;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Modifiers.Crewmate;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -111,8 +110,7 @@ public sealed class ScientistButton : TownOfUsButton, ILegacyCapable
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Modifiers/SecurityButton.cs
+++ b/TownOfUs/Buttons/Modifiers/SecurityButton.cs
@@ -4,7 +4,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Game.Crewmate;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Modifiers.Crewmate;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -113,8 +112,7 @@ public sealed class SecurityButton : TownOfUsButton, ILegacyCapable
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/Modifiers/SpyAdminTableModifierButton.cs
+++ b/TownOfUs/Buttons/Modifiers/SpyAdminTableModifierButton.cs
@@ -4,7 +4,6 @@ using MiraAPI.Modifiers;
 using MiraAPI.Utilities.Assets;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Game.Crewmate;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Roles.Crewmate;
 using UnityEngine;
 
@@ -105,8 +104,7 @@ public sealed class SpyAdminTableModifierButton : TownOfUsButton
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() || PlayerControl.LocalPlayer
-                .GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Buttons/TownOfUsButton.cs
+++ b/TownOfUs/Buttons/TownOfUsButton.cs
@@ -7,7 +7,6 @@ using MiraAPI.Utilities;
 using Reactor.Utilities.Extensions;
 using System.Globalization;
 using TownOfUs.Modifiers;
-using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Modules;
 using TownOfUs.Options;
 using TownOfUs.Options.Maps;
@@ -197,8 +196,7 @@ public abstract class TownOfUsButton : CustomActionButton
 
     public override void ClickHandler()
     {
-        if (!CanClick() || PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() ||
-            PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (!CanClick())
         {
             return;
         }
@@ -418,8 +416,7 @@ public abstract class TownOfUsTargetButton<T> : CustomActionButton<T> where T : 
 
     public override void ClickHandler()
     {
-        if (CanClick() && !PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() &&
-            !PlayerControl.LocalPlayer.HasModifier<DisabledModifier>())
+        if (CanClick())
         {
             if (LimitedUses)
             {
@@ -616,8 +613,7 @@ public abstract class TownOfUsVentRoleButton<TRole> : TownOfUsRoleButton<TRole, 
             return false;
         }
 
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() ||
-            PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
+        if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanUseAbilities))
         {
             return false;
         }

--- a/TownOfUs/Events/Crewmate/EngineerEvents.cs
+++ b/TownOfUs/Events/Crewmate/EngineerEvents.cs
@@ -4,6 +4,7 @@ using MiraAPI.Events.Vanilla.Player;
 using MiraAPI.GameOptions;
 using MiraAPI.Hud;
 using TownOfUs.Buttons.Crewmate;
+using TownOfUs.Events.TouEvents;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
 
@@ -86,6 +87,36 @@ public static class EngineerEvents
                 fixButton.SetUses(fixButton.UsesLeft);
                 ActiveFixTaskCount = 0;
             }
+        }
+    }
+
+    [RegisterEvent]
+    public static void PlumberFlushEngineerHandler(TouAbilityEvent @event)
+    {
+        if (@event.AbilityType is not AbilityType.PlumberFlush)
+        {
+            return;
+        }
+
+        if (PlayerControl.LocalPlayer.Data.Role is not EngineerTouRole ||
+            !PlayerControl.LocalPlayer.inVent)
+        {
+            return;
+        }
+
+        var ventButton = CustomButtonSingleton<EngineerVentButton>.Instance;
+        if (ventButton.Timer != 0)
+        {
+            ventButton.UsesLeft--;
+            if (ventButton.LimitedUses)
+            {
+                ventButton.Button?.SetUsesRemaining(ventButton.UsesLeft);
+            }
+        }
+        if (ventButton.EffectActive || !ventButton.HasEffect)
+        {
+            ventButton.EffectActive = false;
+            ventButton.Timer = ventButton.Cooldown;
         }
     }
 }

--- a/TownOfUs/Modifiers/Neutral/GlitchHackedModifier.cs
+++ b/TownOfUs/Modifiers/Neutral/GlitchHackedModifier.cs
@@ -2,7 +2,6 @@
 using MiraAPI.Events;
 using MiraAPI.GameOptions;
 using MiraAPI.Hud;
-using MiraAPI.Modifiers.Types;
 using TownOfUs.Buttons;
 using TownOfUs.Events.TouEvents;
 using TownOfUs.Options.Roles.Neutral;
@@ -10,11 +9,12 @@ using UnityEngine;
 
 namespace TownOfUs.Modifiers.Neutral;
 
-public sealed class GlitchHackedModifier(byte glitchId) : TimedModifier
+public sealed class GlitchHackedModifier(byte glitchId) : DisabledModifier
 {
     public override string ModifierName => "Hacked";
     public override float Duration => OptionGroupSingleton<GlitchOptions>.Instance.HackDuration;
-    public override bool AutoStart => false;
+    public override bool CanUseAbilities => ShouldHideHacked;
+    public override bool CanReport => ShouldHideHacked;
     public override bool HideOnUi => ShouldHideHacked;
     public byte GlitchId { get; } = glitchId;
 

--- a/TownOfUs/Patches/Roles/GlitchPatches.cs
+++ b/TownOfUs/Patches/Roles/GlitchPatches.cs
@@ -33,12 +33,6 @@ public static class GlitchPatches
     [HarmonyPrefix]
     public static bool GlitchHackedToggleMapVisiblePatch(HudManager __instance)
     {
-        if (PlayerControl.LocalPlayer.HasModifier<GlitchHackedModifier>() &&
-            !PlayerControl.LocalPlayer.GetModifier<GlitchHackedModifier>()!.ShouldHideHacked)
-        {
-            return false;
-        }
-
         if (PlayerControl.LocalPlayer.GetModifiers<DisabledModifier>().Any(x => !x.CanOpenMap))
         {
             return false;

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateProtective/MedicRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateProtective/MedicRole.cs
@@ -103,7 +103,6 @@ public sealed class MedicRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRo
                 MeetingAbilityType.Click,
                 TouAssets.LighterSprite,
                 null!,
-                voteArea => { return Player.Data.IsDead || voteArea!.AmDead; },
                 hoverColor: Color.white)
             {
                 Position = new Vector3(1.1f, -0.18f, -3f)

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateProtective/MedicRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateProtective/MedicRole.cs
@@ -118,7 +118,7 @@ public sealed class MedicRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRo
         if (Player.AmOwner && meeting != null)
         {
             meetingMenu.GenButtons(meeting,
-                Player.AmOwner && !Player.HasDied() && !Player.HasModifier<JailedModifier>());
+                Player.AmOwner && !Player.HasDied());
 
             foreach (var button in meetingMenu.Buttons)
             {


### PR DESCRIPTION
This PR is meant to tackle bugs I have found, reported, and told what the intended functionality is by Atony.

1. Engineer's Vent Button now gets its uses and timer set when forced to exit a vent through the Plumber Flush.
2. Medic now shows its "Lighter/Darker" on all players, regardless of their being dead or the medic being jailed.
3. Glitch Hacked Modifier now inherits from Disabled Modifier, tying its "CanUse" to its internal ShouldHideHacked, to prevent the modifier from existing but not being shown from blocking interactions before it should.