### PR TITLE
Swooper Arrow Tracking and Radar Tracking

### DIFF
--- a/TownOfUs/Modifiers/ArrowTargetModifier.cs
+++ b/TownOfUs/Modifiers/ArrowTargetModifier.cs
@@ -1,9 +1,7 @@
-﻿using MiraAPI.Modifiers;
-using MiraAPI.Modifiers.Types;
+﻿using MiraAPI.Modifiers.Types;
 using MiraAPI.PluginLoading;
 using Reactor.Utilities.Extensions;
-using TownOfUs.Modifiers.Impostor;
-using TownOfUs.Options.Roles.Impostor;
+using TownOfUs.Modules;
 using UnityEngine;
 
 namespace TownOfUs.Modifiers;
@@ -31,7 +29,9 @@ public abstract class ArrowTargetModifier(PlayerControl owner, Color color, floa
 
     public override void OnActivate()
     {
-        _arrow = MiscUtils.CreateArrow(Owner.transform, color);
+        var arrow = MiscUtils.CreateArrow<HideableArrowBehavior>(Owner.transform, color);
+        arrow.Player = Player;
+        _arrow = arrow;
     }
 
     public override void OnDeath(DeathReason reason)
@@ -63,11 +63,6 @@ public abstract class ArrowTargetModifier(PlayerControl owner, Color color, floa
         {
             if (_arrow != null)
             {
-                if (SwoopModifier.CanBeTracked == SwoopTracking.Never)
-                {
-                    _arrow.SetImageEnabled(Player.HasModifier<SwoopModifier>());
-                }
-
                 _arrow.target = Player.transform.position;
                 _arrow.Update();
             }

--- a/TownOfUs/Modifiers/ArrowTargetModifier.cs
+++ b/TownOfUs/Modifiers/ArrowTargetModifier.cs
@@ -1,6 +1,9 @@
-﻿using MiraAPI.Modifiers.Types;
+﻿using MiraAPI.Modifiers;
+using MiraAPI.Modifiers.Types;
 using MiraAPI.PluginLoading;
 using Reactor.Utilities.Extensions;
+using TownOfUs.Modifiers.Impostor;
+using TownOfUs.Options.Roles.Impostor;
 using UnityEngine;
 
 namespace TownOfUs.Modifiers;
@@ -60,6 +63,11 @@ public abstract class ArrowTargetModifier(PlayerControl owner, Color color, floa
         {
             if (_arrow != null)
             {
+                if (SwoopModifier.CanBeTracked == SwoopTracking.Never)
+                {
+                    _arrow.SetImageEnabled(Player.HasModifier<SwoopModifier>());
+                }
+
                 _arrow.target = Player.transform.position;
                 _arrow.Update();
             }

--- a/TownOfUs/Modifiers/Game/Universal/RadarModifier.cs
+++ b/TownOfUs/Modifiers/Game/Universal/RadarModifier.cs
@@ -2,7 +2,9 @@
 using MiraAPI.Modifiers;
 using MiraAPI.Utilities;
 using MiraAPI.Utilities.Assets;
+using TownOfUs.Modifiers.Impostor;
 using TownOfUs.Options.Modifiers;
+using TownOfUs.Options.Roles.Impostor;
 using UnityEngine;
 
 namespace TownOfUs.Modifiers.Game.Universal;
@@ -65,8 +67,10 @@ public sealed class RadarModifier : UniversalGameModifier, IWikiDiscoverable
         var target = Helpers.GetClosestPlayers(Player, float.MaxValue)
             .FirstOrDefault(playerInfo => !playerInfo.Data.Disconnected &&
                                           playerInfo.PlayerId != Player.PlayerId &&
-                                          ((playerInfo.TryGetModifier<DisabledModifier>(out var mod) &&
-                                            mod.IsConsideredAlive) || !playerInfo.HasModifier<DisabledModifier>()) &&
+                                          (!playerInfo.TryGetModifier<DisabledModifier>(out var mod) ||
+                                           mod.IsConsideredAlive) &&
+                                          (!playerInfo.HasModifier<SwoopModifier>() ||
+                                           SwoopModifier.CanBeTracked == SwoopTracking.Always) &&
                                           !playerInfo.Data.IsDead);
         if (!target)
         {

--- a/TownOfUs/Modifiers/Impostor/SwoopModifier.cs
+++ b/TownOfUs/Modifiers/Impostor/SwoopModifier.cs
@@ -19,6 +19,9 @@ public sealed class SwoopModifier : ConcealedModifier, IVisualAppearance
     public override bool HideOnUi => true;
     public override bool AutoStart => true;
     public override bool VisibleToOthers => false;
+
+    public static SwoopTracking CanBeTracked => (SwoopTracking)OptionGroupSingleton<SwooperOptions>.Instance.TrackedMidSwoop.Value;
+
     public bool VisualPriority => true;
     public bool CanSwooperVent = true;
 

--- a/TownOfUs/Modules/HideableArrowBehavior.cs
+++ b/TownOfUs/Modules/HideableArrowBehavior.cs
@@ -1,0 +1,22 @@
+﻿using MiraAPI.Modifiers;
+using TownOfUs.Modifiers.Impostor;
+using TownOfUs.Options.Roles.Impostor;
+
+namespace TownOfUs.Modules;
+
+public class HideableArrowBehavior : ArrowBehaviour
+{
+    public PlayerControl? Player { get; set; }
+
+    public override void UpdatePosition()
+    {
+        var hide = SwoopModifier.CanBeTracked == SwoopTracking.Never &&
+                   Player != null && Player.HasModifier<SwoopModifier>();
+
+        SetImageEnabled(!hide);
+        if (!hide)
+        {
+            base.UpdatePosition();
+        }
+    }
+}

--- a/TownOfUs/Options/Roles/Impostor/SwooperOptions.cs
+++ b/TownOfUs/Options/Roles/Impostor/SwooperOptions.cs
@@ -19,6 +19,9 @@ public sealed class SwooperOptions : AbstractOptionGroup<SwooperRole>
     [ModdedNumberOption("Swoop Duration", 5f, 15f, 2.5f, MiraNumberSuffixes.Seconds)]
     public float SwoopDuration { get; set; } = 10f;
 
+    public ModdedEnumOption TrackedMidSwoop { get; set; } = new("Can be Tracked while Invisible", (int)SwoopTracking.Always, typeof(SwoopTracking),
+        ["Never", "Not by Radar", "Always"]);
+
     public ModdedEnumOption CanVent { get; set; } = new("Swooper Can Vent", (int)SwooperVent.Visible, typeof(SwooperVent),
         ["Never", "While Visible", "Always"]);
 }
@@ -28,4 +31,11 @@ public enum SwooperVent
     Never,
     Visible,
     Always,
+}
+
+public enum SwoopTracking
+{
+    Never,
+    NonRadar,
+    Always
 }

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/AurialRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/AurialRole.cs
@@ -5,6 +5,7 @@ using MiraAPI.Patches.Stubs;
 using MiraAPI.Roles;
 using Reactor.Networking.Attributes;
 using Reactor.Utilities;
+using TownOfUs.Modules;
 using TownOfUs.Options.Roles.Crewmate;
 using UnityEngine;
 using Color = UnityEngine.Color;
@@ -72,7 +73,8 @@ public sealed class AurialRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsR
             color = Palette.PlayerColors[colorID];
         }
 
-        var arrow = MiscUtils.CreateArrow(Player.transform, color);
+        var arrow = MiscUtils.CreateArrow<HideableArrowBehavior>(Player.transform, color);
+        arrow.Player = player;
         arrow.target = position;
 
         try

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SnitchRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SnitchRole.cs
@@ -389,32 +389,26 @@ public sealed class SnitchRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsR
         _snitchArrows = new Dictionary<byte, ArrowBehaviour>();
         var imps = Helpers.GetAlivePlayers().Where(plr => plr.Data.Role.IsImpostor && !plr.IsTraitor());
         var traitor = Helpers.GetAlivePlayers().FirstOrDefault(plr => plr.IsTraitor());
-        imps.ToList().ForEach(imp =>
-        {
-            _snitchArrows.Add(imp.PlayerId, MiscUtils.CreateArrow(imp.transform, TownOfUsColors.Impostor));
-            PlayerNameColor.Set(imp);
-            imp.AddModifier<SnitchImpostorRevealModifier>();
-        });
+        imps.ToList().ForEach(imp => CreateSnitchArrow(imp, TownOfUsColors.Impostor));
 
         if (OptionGroupSingleton<SnitchOptions>.Instance.SnitchSeesTraitor && traitor != null)
         {
-            _snitchArrows.Add(traitor.PlayerId, MiscUtils.CreateArrow(traitor.transform, TownOfUsColors.Impostor));
-            PlayerNameColor.Set(traitor);
-            traitor.AddModifier<SnitchImpostorRevealModifier>();
+            CreateSnitchArrow(traitor, TownOfUsColors.Impostor);
         }
 
         if (OptionGroupSingleton<SnitchOptions>.Instance.SnitchNeutralRoles)
         {
             var neutrals = MiscUtils.GetRoles(RoleAlignment.NeutralKilling)
                 .Where(role => !role.Player.Data.IsDead && !role.Player.Data.Disconnected);
-            neutrals.ToList().ForEach(neutral =>
-            {
-                _snitchArrows.Add(neutral.Player.PlayerId,
-                    MiscUtils.CreateArrow(neutral.Player.transform, TownOfUsColors.Neutral));
-                PlayerNameColor.Set(neutral.Player);
-                neutral.Player.AddModifier<SnitchImpostorRevealModifier>();
-            });
+            neutrals.ToList().ForEach(neutral => CreateSnitchArrow(neutral.Player, TownOfUsColors.Neutral));
         }
+    }
+
+    private void CreateSnitchArrow(PlayerControl player, Color color)
+    {
+        _snitchArrows!.Add(player.PlayerId, MiscUtils.CreateArrow(player.transform, color));
+        PlayerNameColor.Set(player);
+        player.AddModifier<SnitchImpostorRevealModifier>();
     }
 
     public void AddSnitchTraitorArrows()

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SnitchRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SnitchRole.cs
@@ -12,6 +12,7 @@ using TownOfUs.Events;
 using TownOfUs.Interfaces;
 using TownOfUs.Modifiers.Crewmate;
 using TownOfUs.Modifiers.Game.Alliance;
+using TownOfUs.Modules;
 using TownOfUs.Options.Roles.Crewmate;
 using UnityEngine;
 
@@ -406,7 +407,9 @@ public sealed class SnitchRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsR
 
     private void CreateSnitchArrow(PlayerControl player, Color color)
     {
-        _snitchArrows!.Add(player.PlayerId, MiscUtils.CreateArrow(player.transform, color));
+        var arrow = MiscUtils.CreateArrow<HideableArrowBehavior>(player.transform, color);
+        arrow.Player = player;
+        _snitchArrows!.Add(player.PlayerId, arrow);
         PlayerNameColor.Set(player);
         player.AddModifier<SnitchImpostorRevealModifier>();
     }

--- a/TownOfUs/Utilities/MiscUtils.cs
+++ b/TownOfUs/Utilities/MiscUtils.cs
@@ -1399,6 +1399,11 @@ public static class MiscUtils
 
     public static ArrowBehaviour CreateArrow(Transform parent, Color color)
     {
+        return CreateArrow<ArrowBehaviour>(parent, color);
+    }
+
+    public static TArrow CreateArrow<TArrow>(Transform parent, Color color) where TArrow : ArrowBehaviour
+    {
         var gameObject = new GameObject("Arrow")
         {
             layer = 5,
@@ -1412,7 +1417,7 @@ public static class MiscUtils
         renderer.sprite = TouAssets.ArrowSprite.LoadAsset();
         renderer.color = color;
 
-        var arrow = gameObject.AddComponent<ArrowBehaviour>();
+        var arrow = gameObject.AddComponent<TArrow>();
         arrow.image = renderer;
         arrow.image.color = color;
 


### PR DESCRIPTION
Cherry-picked from #199

Extended the way ArrowBehaviour was used to allow for potential ways to have arrows be hidden when Swooper goes invisible. Added option for Radar modifier to not account for invisible Swoopers when finding their closest target to point an arrow to.