### PR TITLE
Add Deputy setting to warn killer on camped kill

### DIFF
--- a/TownOfUs/Events/Crewmate/DeputyEvents.cs
+++ b/TownOfUs/Events/Crewmate/DeputyEvents.cs
@@ -1,5 +1,6 @@
 ﻿using MiraAPI.Events;
 using MiraAPI.Events.Vanilla.Gameplay;
+using MiraAPI.GameOptions;
 using MiraAPI.Modifiers;
 using MiraAPI.Roles;
 using MiraAPI.Utilities;
@@ -7,6 +8,7 @@ using Reactor.Utilities;
 using TownOfUs.Modifiers.Crewmate;
 using TownOfUs.Modifiers.Game;
 using TownOfUs.Modules;
+using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
 using UnityEngine;
 
@@ -97,6 +99,14 @@ public static class DeputyEvents
                 Color.white, new Vector3(0f, 1f, -20f), spr: TouRoleIcons.Deputy.LoadAsset());
 
             notif1.AdjustNotification();
+            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Deputy));
+        }
+        if (source.AmOwner && OptionGroupSingleton<DeputyOptions>.Instance.WarnKiller)
+        {
+            var notif = Helpers.CreateAndShowNotification(
+                $"<b>{TownOfUsColors.Deputy.ToTextColor()}{TouLocale.GetParsed("TouRoleDeputyKillerWarnNotif")}</color></b>",
+                Color.white, new Vector3(0f, 1f, -20f), spr: TouRoleIcons.Deputy.LoadAsset());
+            notif.AdjustNotification();
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Deputy));
         }
     }

--- a/TownOfUs/Options/Roles/Crewmate/DeputyOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/DeputyOptions.cs
@@ -1,0 +1,15 @@
+﻿using MiraAPI.GameOptions;
+using MiraAPI.GameOptions.Attributes;
+using MiraAPI.GameOptions.OptionTypes;
+using MiraAPI.Utilities;
+using TownOfUs.Roles.Crewmate;
+
+namespace TownOfUs.Options.Roles.Crewmate;
+
+public sealed class DeputyOptions : AbstractOptionGroup<DeputyRole>
+{
+    public override string GroupName => TouLocale.Get("TouRoleDeputy", "Deputy");
+
+    [ModdedToggleOption("TouOptionDeputyWarnKillerOnCampedKill")]
+    public bool WarnKiller { get; set; } = false;
+}

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -743,8 +743,11 @@
   <!-- Deputy Feedback -->
   <string name="TouRoleDeputyCampNotif">Wait for \%player\%'s death so you can blast their killer in the meeting.</string>
   <string name="TouRoleDeputyCampedKillNotif">Your camped target, \%player\%, has died! Avenge them in the meeting.</string>
+  <string name="TouRoleDeputyKillerWarnNotif">A Deputy had camped your victim, watch out! </string>
   <string name="TouRoleDeputyMessageTitle">Deputy Feedback</string>
   <string name="TouRoleDeputyMissedShot">You missed your shot! They are either not the killer or are invincible.</string>
+  <!-- Deputy Options -->
+  <string name="TouOptionDeputyWarnKillerOnCampedKill">Warn Killer Upon Killing Camped Target</string>
   <!-- Forensic - Crewmate Investigative -->
   <!-- Forensic Wiki / Abilities -->
   <string name="TouRoleForensic">Forensic</string>


### PR DESCRIPTION
## Summary
Adds a new Deputy option: **Warn Killer Upon Killing Camped Target** (default: off).

When set on True, if a killer kills a camped person by the Deputy the killer receives:
- A Deputy colored screen flash
- A notification on the bottom right: "A Deputy had camped your victim, watch out!"

When the setting is set on False, behavior is unchanged aka only Deputy receives the flash

## Motivation
This gives the killer counterplay/awareness that they've been caught by a Deputy, giving them the awareness to try to avoid the undetectable insta kill ability and make it less jarring (one example: not self reporting immediately since now they'd know Deputy has the kill timing) and the added notification to inform new players who don't know what the color flashed means.

## Changes
- Added `DeputyOptions.cs` (Deputy had no options before)
- Added the killer flash + notification in `DeputyEvents.cs` (`CheckForDeputyCamped`)
- Added locale strings in `en_US.xml` for the settings label and notification

## Testing
Tested in-game: Setting appears properly, the killer receives the flash and notification on a camped kill; with it on false, behavior is unchanged.
