### PR TITLE
Single phone UI

### DIFF
--- a/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
+++ b/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
@@ -71,10 +71,14 @@ public sealed class RemoteKillButton : TownOfUsButton
                 if (target1 == null) // Set the Killer
                 {
                     target1 = plr;
+                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    // set outline for targetPanel
                     return;
                 }
                 if (target1.PlayerId == plr.PlayerId) // Unselect the Killer
                 {
+                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    // clear outline for targetPanel
                     Killer = null;
                     return;
                 }

--- a/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
+++ b/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
@@ -72,12 +72,14 @@ public sealed class RemoteKillButton : TownOfUsButton
                 {
                     target1 = plr;
                     var targetPanel = playerMenu.GetVictimPanel(target1.Data);
+                    var targetHighlight = targetPanel.gameObject.transform.FindChild("Nameplate").FindChild("Highlight");
                     // set outline for targetPanel
                     return;
                 }
                 if (target1.PlayerId == plr.PlayerId) // Unselect the Killer
                 {
                     var targetPanel = playerMenu.GetVictimPanel(target1.Data);
+                    var targetHighlight = targetPanel.gameObject.transform.FindChild("Nameplate").FindChild("Highlight");
                     // clear outline for targetPanel
                     Killer = null;
                     return;

--- a/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
+++ b/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
@@ -71,13 +71,13 @@ public sealed class RemoteKillButton : TownOfUsButton
                 if (target1 == null) // Set the Killer
                 {
                     target1 = plr;
-                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    var targetPanel = playerMenu.GetVictimPanel(target1.Data);
                     // set outline for targetPanel
                     return;
                 }
                 if (target1.PlayerId == plr.PlayerId) // Unselect the Killer
                 {
-                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    var targetPanel = playerMenu.GetVictimPanel(target1.Data);
                     // clear outline for targetPanel
                     Killer = null;
                     return;

--- a/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
+++ b/TownOfUs/Buttons/BaseFreeplay/RemoteKillButton.cs
@@ -39,6 +39,8 @@ public sealed class RemoteKillButton : TownOfUsButton
                !FreeplayButtonsVisibility.Hidden;
     }
 
+    private PlayerControl? target1;
+
     protected override void OnClick()
     {
         PlayerControl.LocalPlayer.NetTransform.Halt();
@@ -51,57 +53,42 @@ public sealed class RemoteKillButton : TownOfUsButton
         Killer = null;
         Victim = null;
 
-        var player1Menu = CustomPlayerMenu.Create();
-        player1Menu.transform.FindChild("PhoneUI").GetChild(0).GetComponent<SpriteRenderer>().material =
+        var playerMenu = CustomPlayerMenu.Create();
+        playerMenu.transform.FindChild("PhoneUI").GetChild(0).GetComponent<SpriteRenderer>().material =
             PlayerControl.LocalPlayer.cosmetics.currentBodySprite.BodySprite.material;
-        player1Menu.transform.FindChild("PhoneUI").GetChild(1).GetComponent<SpriteRenderer>().material =
+        playerMenu.transform.FindChild("PhoneUI").GetChild(1).GetComponent<SpriteRenderer>().material =
             PlayerControl.LocalPlayer.cosmetics.currentBodySprite.BodySprite.material;
 
-        player1Menu.Begin(
+        playerMenu.Begin(
             plr => !plr.Data.Disconnected &&
                    (plr.moveable || plr.inVent),
             plr =>
             {
-                player1Menu.ForceClose();
-
                 if (plr == null)
                 {
                     return;
                 }
-
-                var player2Menu = CustomPlayerMenu.Create();
-                player2Menu.transform.FindChild("PhoneUI").GetChild(0).GetComponent<SpriteRenderer>().material =
-                    plr.cosmetics.currentBodySprite.BodySprite.material;
-                player2Menu.transform.FindChild("PhoneUI").GetChild(1).GetComponent<SpriteRenderer>().material =
-                    plr.cosmetics.currentBodySprite.BodySprite.material;
-
-                player2Menu.Begin(
-                    plr2 => !plr2.Data.Disconnected && !plr2.Data.IsDead &&
-                            (plr2.moveable || plr2.inVent),
-                    plr2 =>
-                    {
-                        player2Menu.Close();
-                        if (plr2 == null)
-                        {
-                            return;
-                        }
-
-                        Killer = plr;
-                        Victim = plr2;
-                        EffectActive = true;
-                        Timer = EffectDuration;
-                    }
-                );
-                foreach (var panel in player2Menu.potentialVictims)
+                if (target1 == null) // Set the Killer
                 {
-                    if (panel.NameText.text != PlayerControl.LocalPlayer.Data.PlayerName)
-                    {
-                        panel.NameText.color = Color.white;
-                    }
+                    target1 = plr;
+                    return;
                 }
+                if (target1.PlayerId == plr.PlayerId) // Unselect the Killer
+                {
+                    Killer = null;
+                    return;
+                }
+                playerMenu.Close();
+
+                Killer = target1;
+                Victim = plr;
+                EffectActive = true;
+                Timer = EffectDuration;
+
+                target1 = null;
             }
         );
-        foreach (var panel in player1Menu.potentialVictims)
+        foreach (var panel in playerMenu.potentialVictims)
         {
             if (panel.NameText.text != PlayerControl.LocalPlayer.Data.PlayerName)
             {

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
@@ -64,12 +64,14 @@ public sealed class TransporterTransportButton : TownOfUsRoleButton<TransporterR
                 {
                     target1 = plr;
                     var targetPanel = playerMenu.GetVictimPanel(target1.Data);
+                    var targetHighlight = targetPanel.gameObject.transform.FindChild("Nameplate").FindChild("Highlight");
                     // set outline for targetPanel
                     return;
                 }
                 if (target1.PlayerId == plr.PlayerId) // Unselect first choice
                 {
                     var targetPanel = playerMenu.GetVictimPanel(target1.Data);
+                    var targetHighlight = targetPanel.gameObject.transform.FindChild("Nameplate").FindChild("Highlight");
                     // clear outline for targetPanel
                     target1 = null;
                     return;

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
@@ -63,10 +63,14 @@ public sealed class TransporterTransportButton : TownOfUsRoleButton<TransporterR
                 if (target1 == null) // Set first choice
                 {
                     target1 = plr;
+                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    // set outline for targetPanel
                     return;
                 }
                 if (target1.PlayerId == plr.PlayerId) // Unselect first choice
                 {
+                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    // clear outline for targetPanel
                     target1 = null;
                     return;
                 }

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
@@ -30,6 +30,8 @@ public sealed class TransporterTransportButton : TownOfUsRoleButton<TransporterR
         OnClick();
     }
 
+    private PlayerControl? target1;
+
     protected override void OnClick()
     {
         if (!OptionGroupSingleton<TransporterOptions>.Instance.MoveWithMenu)
@@ -42,57 +44,41 @@ public sealed class TransporterTransportButton : TownOfUsRoleButton<TransporterR
             return;
         }
 
-        var player1Menu = CustomPlayerMenu.Create();
-        player1Menu.transform.FindChild("PhoneUI").GetChild(0).GetComponent<SpriteRenderer>().material =
+        var playerMenu = CustomPlayerMenu.Create();
+        playerMenu.transform.FindChild("PhoneUI").GetChild(0).GetComponent<SpriteRenderer>().material =
             PlayerControl.LocalPlayer.cosmetics.currentBodySprite.BodySprite.material;
-        player1Menu.transform.FindChild("PhoneUI").GetChild(1).GetComponent<SpriteRenderer>().material =
+        playerMenu.transform.FindChild("PhoneUI").GetChild(1).GetComponent<SpriteRenderer>().material =
             PlayerControl.LocalPlayer.cosmetics.currentBodySprite.BodySprite.material;
 
-        player1Menu.Begin(
+        playerMenu.Begin(
             plr => ((!plr.Data.Disconnected && !plr.Data.IsDead) || Helpers.GetBodyById(plr.PlayerId)) &&
                    (plr.moveable || plr.inVent),
             plr =>
             {
-                player1Menu.ForceClose();
-
                 if (plr == null)
                 {
                     return;
                 }
 
-                var player2Menu = CustomPlayerMenu.Create();
-                player2Menu.transform.FindChild("PhoneUI").GetChild(0).GetComponent<SpriteRenderer>().material =
-                    PlayerControl.LocalPlayer.cosmetics.currentBodySprite.BodySprite.material;
-                player2Menu.transform.FindChild("PhoneUI").GetChild(1).GetComponent<SpriteRenderer>().material =
-                    PlayerControl.LocalPlayer.cosmetics.currentBodySprite.BodySprite.material;
-
-                player2Menu.Begin(
-                    plr2 => plr2.PlayerId != plr.PlayerId &&
-                            (!plr2.HasDied() ||
-                             Helpers.GetBodyById(plr2.PlayerId) /*  || MiscUtils.GetFakePlayer(plr2)?.body */) &&
-                            (plr2.moveable || plr2.inVent),
-                    plr2 =>
-                    {
-                        player2Menu.Close();
-                        if (plr2 == null)
-                        {
-                            return;
-                        }
-
-                        TransporterRole.RpcTransport(PlayerControl.LocalPlayer, plr.PlayerId, plr2.PlayerId);
-                    }
-                );
-                foreach (var panel in player2Menu.potentialVictims)
+                if (target1 == null) // Set first choice
                 {
-                    panel.PlayerIcon.cosmetics.SetPhantomRoleAlpha(1f);
-                    if (panel.NameText.text != PlayerControl.LocalPlayer.Data.PlayerName)
-                    {
-                        panel.NameText.color = Color.white;
-                    }
+                    target1 = plr;
+                    return;
                 }
+                if (target1.PlayerId == plr.PlayerId) // Unselect first choice
+                {
+                    target1 = null;
+                    return;
+                }
+
+                playerMenu.Close();
+
+                TransporterRole.RpcTransport(PlayerControl.LocalPlayer, target1.PlayerId, plr.PlayerId);
+
+                target1 = null;
             }
         );
-        foreach (var panel in player1Menu.potentialVictims)
+        foreach (var panel in playerMenu.potentialVictims)
         {
             panel.PlayerIcon.cosmetics.SetPhantomRoleAlpha(1f);
             if (panel.NameText.text != PlayerControl.LocalPlayer.Data.PlayerName)

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateSupport/TransporterTransportButton.cs
@@ -63,13 +63,13 @@ public sealed class TransporterTransportButton : TownOfUsRoleButton<TransporterR
                 if (target1 == null) // Set first choice
                 {
                     target1 = plr;
-                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    var targetPanel = playerMenu.GetVictimPanel(target1.Data);
                     // set outline for targetPanel
                     return;
                 }
                 if (target1.PlayerId == plr.PlayerId) // Unselect first choice
                 {
-                    var targetPanel = playerMenu.potentialVictims.First(victim => victim.NameText.text == target1.Data.PlayerName);
+                    var targetPanel = playerMenu.GetVictimPanel(target1.Data);
                     // clear outline for targetPanel
                     target1 = null;
                     return;

--- a/TownOfUs/Utilities/Extensions.cs
+++ b/TownOfUs/Utilities/Extensions.cs
@@ -3,6 +3,7 @@ using AmongUs.GameOptions;
 using LibCpp2IL;
 using MiraAPI.Events;
 using MiraAPI.GameOptions;
+using MiraAPI.Hud;
 using MiraAPI.Modifiers;
 using MiraAPI.Roles;
 using MiraAPI.Utilities;
@@ -425,6 +426,12 @@ public static class Extensions
         panel.NameText.text = finalString;
         panel.NameText.alignment = TextAlignmentOptions.Right;
         panel.NameText.transform.localPosition += Vector3.left * 0.05f;
+    }
+
+    public static ShapeshifterPanel GetVictimPanel(this CustomPlayerMenu playerMenu, NetworkedPlayerInfo player)
+    {
+        return playerMenu.potentialVictims.First(victim =>
+            victim.NameText.text == player.PlayerName || victim.ColorBlindName.text == player.PlayerName);
     }
 
     [MethodRpc((uint)TownOfUsRpc.ChangeRole)]


### PR DESCRIPTION
Buttons that rely on two separate CustomPlayerMenu to select two separate players (for now being Transporter and Remote Kill Button) can now do so in a single phone UI, with the ability to deselect the first selection.

Draft because the UI can't really show the current first selection yet besides being tracked internally.