### PR TITLE
Plaguebearer Pestilence Rework 

### DIFF
--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/ArsonistIgniteButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/ArsonistIgniteButton.cs
@@ -72,15 +72,10 @@ public sealed class ArsonistIgniteButton : TownOfUsRoleButton<ArsonistRole>, ILe
             ? ModifierUtils.GetPlayersWithModifier<ArsonistDousedModifier>().ToList()
             : PlayersInRange.Where(x => x.HasModifier<ArsonistDousedModifier>()).ToList();
 
-        // A Pestilence only retaliates when it is the *direct* victim of this ignite:
-        //   - Legacy: the player we ignited on (ClosestTarget) is the Pestilence.
-        //   - Non-legacy: the Pestilence is within the ignite radius.
-        // Being incidentally doused elsewhere does NOT trigger a kill-back.
         var retaliatingPest = legacy
             ? (ClosestTarget != null && ClosestTarget.Data.Role is PestilenceRole ? ClosestTarget : null)
             : dousedPlayers.FirstOrDefault(x => x.Data.Role is PestilenceRole);
 
-        // The Pestilence is invulnerable, so exclude it from the mass murder; it retaliates instead.
         var victims = dousedPlayers.Where(x => x.Data.Role is not PestilenceRole).ToList();
 
         if (victims.Count > 0)
@@ -91,7 +86,6 @@ public sealed class ArsonistIgniteButton : TownOfUsRoleButton<ArsonistRole>, ILe
                 causeOfDeath: "Arsonist");
         }
 
-        // Igniting directly on the Pestilence gets the Arsonist killed, reliably (no indirect race).
         retaliatingPest?.RpcCustomMurder(PlayerControl.LocalPlayer, MeetingCheck.OutsideMeeting);
 
         if (victims.Count > 0 || retaliatingPest != null)

--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/ArsonistIgniteButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/ArsonistIgniteButton.cs
@@ -66,17 +66,36 @@ public sealed class ArsonistIgniteButton : TownOfUsRoleButton<ArsonistRole>, ILe
 
     protected override void OnClick()
     {
-        var dousedPlayers = OptionGroupSingleton<ArsonistOptions>.Instance.LegacyArsonist
+        var legacy = OptionGroupSingleton<ArsonistOptions>.Instance.LegacyArsonist;
+
+        var dousedPlayers = legacy
             ? ModifierUtils.GetPlayersWithModifier<ArsonistDousedModifier>().ToList()
             : PlayersInRange.Where(x => x.HasModifier<ArsonistDousedModifier>()).ToList();
 
-        if (dousedPlayers.Count > 0)
+        // A Pestilence only retaliates when it is the *direct* victim of this ignite:
+        //   - Legacy: the player we ignited on (ClosestTarget) is the Pestilence.
+        //   - Non-legacy: the Pestilence is within the ignite radius.
+        // Being incidentally doused elsewhere does NOT trigger a kill-back.
+        var retaliatingPest = legacy
+            ? (ClosestTarget != null && ClosestTarget.Data.Role is PestilenceRole ? ClosestTarget : null)
+            : dousedPlayers.FirstOrDefault(x => x.Data.Role is PestilenceRole);
+
+        // The Pestilence is invulnerable, so exclude it from the mass murder; it retaliates instead.
+        var victims = dousedPlayers.Where(x => x.Data.Role is not PestilenceRole).ToList();
+
+        if (victims.Count > 0)
         {
-            PlayerControl.LocalPlayer.RpcSpecialMultiMurder(dousedPlayers, MeetingCheck.OutsideMeeting, true,
+            PlayerControl.LocalPlayer.RpcSpecialMultiMurder(victims, MeetingCheck.OutsideMeeting, true,
                 teleportMurderer: false,
                 playKillSound: false,
                 causeOfDeath: "Arsonist");
+        }
 
+        // Igniting directly on the Pestilence gets the Arsonist killed, reliably (no indirect race).
+        retaliatingPest?.RpcCustomMurder(PlayerControl.LocalPlayer, MeetingCheck.OutsideMeeting);
+
+        if (victims.Count > 0 || retaliatingPest != null)
+        {
             TouAudio.PlaySound(TouAudio.ArsoIgniteSound);
 
             CustomButtonSingleton<ArsonistDouseButton>.Instance.ResetCooldownAndOrEffect();

--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/PestilenceKillButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/PestilenceKillButton.cs
@@ -56,7 +56,7 @@ public sealed class PestilenceKillButton : TownOfUsKillRoleButton<PestilenceRole
     {
         var chainKill = CanClick() && Target != null &&
                         !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence &&
-                        Target.HasModifier<PestilenceStackModifier>();
+                        Target.HasModifier<TerminalPestilenceModifier>();
 
         base.ClickHandler();
 

--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/PestilenceKillButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/PestilenceKillButton.cs
@@ -54,8 +54,6 @@ public sealed class PestilenceKillButton : TownOfUsKillRoleButton<PestilenceRole
 
     public override void ClickHandler()
     {
-        // Killing a player who interacted with the Pestilence (a "stack") resets the kill
-        // cooldown to 0 so it can immediately kill again. Disabled in Legacy Mode.
         var chainKill = CanClick() && Target != null &&
                         !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence &&
                         Target.HasModifier<PestilenceStackModifier>();

--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/PestilenceKillButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/PestilenceKillButton.cs
@@ -1,7 +1,9 @@
 using MiraAPI.GameOptions;
+using MiraAPI.Modifiers;
 using MiraAPI.Networking;
 using MiraAPI.Utilities.Assets;
 using Reactor.Utilities;
+using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Options.Modifiers.Alliance;
 using TownOfUs.Options.Roles.Neutral;
 using TownOfUs.Roles.Neutral;
@@ -48,5 +50,21 @@ public sealed class PestilenceKillButton : TownOfUsKillRoleButton<PestilenceRole
         }
 
         PlayerControl.LocalPlayer.RpcCustomMurder(Target, MeetingCheck.OutsideMeeting);
+    }
+
+    public override void ClickHandler()
+    {
+        // Killing a player who interacted with the Pestilence (a "stack") resets the kill
+        // cooldown to 0 so it can immediately kill again. Disabled in Legacy Mode.
+        var chainKill = CanClick() && Target != null &&
+                        !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence &&
+                        Target.HasModifier<PestilenceStackModifier>();
+
+        base.ClickHandler();
+
+        if (chainKill)
+        {
+            SetTimer(0f);
+        }
     }
 }

--- a/TownOfUs/Events/Crewmate/ClericEvents.cs
+++ b/TownOfUs/Events/Crewmate/ClericEvents.cs
@@ -73,7 +73,7 @@ public static class ClericEvents
 
         if (!target.HasModifier<ClericBarrierModifier>() ||
             target.PlayerId == source.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield))
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
         {
             return false;
         }

--- a/TownOfUs/Events/Crewmate/ClericEvents.cs
+++ b/TownOfUs/Events/Crewmate/ClericEvents.cs
@@ -73,7 +73,7 @@ public static class ClericEvents
 
         if (!target.HasModifier<ClericBarrierModifier>() ||
             target.PlayerId == source.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.HasModifier<UnstoppableModifier>())
         {
             return false;
         }

--- a/TownOfUs/Events/Crewmate/MedicEvents.cs
+++ b/TownOfUs/Events/Crewmate/MedicEvents.cs
@@ -165,7 +165,7 @@ public static class MedicEvents
 
         if (!target.HasModifier<MedicShieldModifier>() ||
             target.PlayerId == source.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.HasModifier<UnstoppableModifier>())
         {
             return false;
         }

--- a/TownOfUs/Events/Crewmate/MedicEvents.cs
+++ b/TownOfUs/Events/Crewmate/MedicEvents.cs
@@ -165,7 +165,7 @@ public static class MedicEvents
 
         if (!target.HasModifier<MedicShieldModifier>() ||
             target.PlayerId == source.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield))
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
         {
             return false;
         }

--- a/TownOfUs/Events/Crewmate/VeteranEvents.cs
+++ b/TownOfUs/Events/Crewmate/VeteranEvents.cs
@@ -115,7 +115,7 @@ public static class VeteranEvents
                 }
             }
             if (!OptionGroupSingleton<VeteranOptions>.Instance.KilledOnAlert &&
-                (indirectMod == null || !indirectMod.IgnoreShield) && !source.IsUnstoppablePest())
+                (indirectMod == null || !indirectMod.IgnoreShield) && !source.HasModifier<UnstoppableModifier>())
             {
                 miraEvent.Cancel();
             }

--- a/TownOfUs/Events/Crewmate/VeteranEvents.cs
+++ b/TownOfUs/Events/Crewmate/VeteranEvents.cs
@@ -115,7 +115,7 @@ public static class VeteranEvents
                 }
             }
             if (!OptionGroupSingleton<VeteranOptions>.Instance.KilledOnAlert &&
-                (indirectMod == null || !indirectMod.IgnoreShield))
+                (indirectMod == null || !indirectMod.IgnoreShield) && !source.IsUnstoppablePest())
             {
                 miraEvent.Cancel();
             }

--- a/TownOfUs/Events/Crewmate/WardenEvents.cs
+++ b/TownOfUs/Events/Crewmate/WardenEvents.cs
@@ -94,7 +94,7 @@ public static class WardenEvents
         }
 
         if (!target.HasModifier<WardenFortifiedModifier>() || source == target ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield))
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
         {
             return;
         }

--- a/TownOfUs/Events/Crewmate/WardenEvents.cs
+++ b/TownOfUs/Events/Crewmate/WardenEvents.cs
@@ -94,7 +94,7 @@ public static class WardenEvents
         }
 
         if (!target.HasModifier<WardenFortifiedModifier>() || source == target ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.HasModifier<UnstoppableModifier>())
         {
             return;
         }

--- a/TownOfUs/Events/Impostor/HerbalistEvents.cs
+++ b/TownOfUs/Events/Impostor/HerbalistEvents.cs
@@ -65,7 +65,7 @@ public static class HerbalistEvents
         if (!target.TryGetModifier<HerbalistProtectionModifier>(out var protectMod) ||
             protectMod.Herbalist.PlayerId == source.PlayerId ||
             target.PlayerId == source.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.HasModifier<UnstoppableModifier>())
         {
             return false;
         }

--- a/TownOfUs/Events/Impostor/HerbalistEvents.cs
+++ b/TownOfUs/Events/Impostor/HerbalistEvents.cs
@@ -65,7 +65,7 @@ public static class HerbalistEvents
         if (!target.TryGetModifier<HerbalistProtectionModifier>(out var protectMod) ||
             protectMod.Herbalist.PlayerId == source.PlayerId ||
             target.PlayerId == source.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield))
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
         {
             return false;
         }

--- a/TownOfUs/Events/InvulnerabilityEvents.cs
+++ b/TownOfUs/Events/InvulnerabilityEvents.cs
@@ -1,11 +1,15 @@
 ﻿using MiraAPI.Events;
 using MiraAPI.Events.Mira;
 using MiraAPI.Events.Vanilla.Gameplay;
+using MiraAPI.GameOptions;
 using MiraAPI.Hud;
 using MiraAPI.Modifiers;
 using MiraAPI.Networking;
 using TownOfUs.Buttons;
 using TownOfUs.Modifiers;
+using TownOfUs.Modifiers.Neutral;
+using TownOfUs.Options.Roles.Neutral;
+using TownOfUs.Roles.Neutral;
 
 namespace TownOfUs.Events;
 
@@ -56,7 +60,23 @@ public static class InvulnerabilityEvents
             if (source.AmOwner && ((invic.AttackMurderer && killAttempt) || invic.AttackAllInteractions) &&
                 !source.HasModifier<IndirectAttackerModifier>())
             {
-                target.RpcCustomMurder(source, MeetingCheck.OutsideMeeting);
+                // Pestilence rework: outside of Legacy Mode, a non-lethal interaction marks the
+                // interactor with a stack (visible only to Pestilence) instead of instantly killing
+                // them. Kill attempts still get killed back, exactly as before.
+                var pestRework = target.Data.Role is PestilenceRole &&
+                                 !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence;
+
+                if (pestRework && !killAttempt)
+                {
+                    if (!source.HasModifier<PestilenceStackModifier>())
+                    {
+                        source.RpcAddModifier<PestilenceStackModifier>(target.PlayerId);
+                    }
+                }
+                else
+                {
+                    target.RpcCustomMurder(source, MeetingCheck.OutsideMeeting);
+                }
             }
         }
     }

--- a/TownOfUs/Events/InvulnerabilityEvents.cs
+++ b/TownOfUs/Events/InvulnerabilityEvents.cs
@@ -69,6 +69,8 @@ public static class InvulnerabilityEvents
                     {
                         source.RpcAddModifier<PestilenceStackModifier>(target.PlayerId);
                     }
+
+                    PestilenceRole.RpcHorsemanSensed(target);
                 }
                 else
                 {

--- a/TownOfUs/Events/InvulnerabilityEvents.cs
+++ b/TownOfUs/Events/InvulnerabilityEvents.cs
@@ -60,9 +60,6 @@ public static class InvulnerabilityEvents
             if (source.AmOwner && ((invic.AttackMurderer && killAttempt) || invic.AttackAllInteractions) &&
                 !source.HasModifier<IndirectAttackerModifier>())
             {
-                // Pestilence rework: outside of Legacy Mode, a non-lethal interaction marks the
-                // interactor with a stack (visible only to Pestilence) instead of instantly killing
-                // them. Kill attempts still get killed back, exactly as before.
                 var pestRework = target.Data.Role is PestilenceRole &&
                                  !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence;
 

--- a/TownOfUs/Events/InvulnerabilityEvents.cs
+++ b/TownOfUs/Events/InvulnerabilityEvents.cs
@@ -65,9 +65,9 @@ public static class InvulnerabilityEvents
 
                 if (pestRework && !killAttempt)
                 {
-                    if (!source.HasModifier<PestilenceStackModifier>())
+                    if (!source.HasModifier<TerminalPestilenceModifier>())
                     {
-                        source.RpcAddModifier<PestilenceStackModifier>(target.PlayerId);
+                        source.RpcAddModifier<TerminalPestilenceModifier>(target.PlayerId);
                     }
 
                     PestilenceRole.RpcHorsemanSensed(target);

--- a/TownOfUs/Events/Misc/FirstShieldEvents.cs
+++ b/TownOfUs/Events/Misc/FirstShieldEvents.cs
@@ -54,7 +54,7 @@ public static class FirstShieldEvents
         }
 
         if (!target.HasModifier<FirstDeadShield>() || source == target ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.HasModifier<UnstoppableModifier>())
         {
             return;
         }

--- a/TownOfUs/Events/Misc/FirstShieldEvents.cs
+++ b/TownOfUs/Events/Misc/FirstShieldEvents.cs
@@ -54,7 +54,7 @@ public static class FirstShieldEvents
         }
 
         if (!target.HasModifier<FirstDeadShield>() || source == target ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield))
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
         {
             return;
         }

--- a/TownOfUs/Events/Neutral/GuardianAngelEvents.cs
+++ b/TownOfUs/Events/Neutral/GuardianAngelEvents.cs
@@ -83,7 +83,7 @@ public static class GuardianAngelEvents
 
         if (!target.HasModifier<GuardianAngelProtectModifier>() ||
             source.PlayerId == target.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.HasModifier<UnstoppableModifier>())
         {
             return false;
         }

--- a/TownOfUs/Events/Neutral/GuardianAngelEvents.cs
+++ b/TownOfUs/Events/Neutral/GuardianAngelEvents.cs
@@ -83,7 +83,7 @@ public static class GuardianAngelEvents
 
         if (!target.HasModifier<GuardianAngelProtectModifier>() ||
             source.PlayerId == target.PlayerId ||
-            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield))
+            (source.TryGetModifier<IndirectAttackerModifier>(out var indirect) && indirect.IgnoreShield) || source.IsUnstoppablePest())
         {
             return false;
         }

--- a/TownOfUs/Events/Neutral/PlaguebearerEvents.cs
+++ b/TownOfUs/Events/Neutral/PlaguebearerEvents.cs
@@ -2,8 +2,10 @@
 using MiraAPI.Events.Mira;
 using MiraAPI.Events.Vanilla.Gameplay;
 using MiraAPI.Events.Vanilla.Meeting;
+using MiraAPI.GameOptions;
 using MiraAPI.Hud;
 using TownOfUs.Buttons.Neutral;
+using TownOfUs.Options.Roles.Neutral;
 using TownOfUs.Roles.Neutral;
 
 namespace TownOfUs.Events.Neutral;
@@ -50,5 +52,11 @@ public static class PlaguebearerEvents
         }
 
         PlaguebearerRole.RpcCheckInfected(source, target);
+
+        if (target.Data.Role is PlaguebearerRole &&
+            !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+        {
+            PestilenceRole.RpcHorsemanSensed(target);
+        }
     }
 }

--- a/TownOfUs/Events/Neutral/PlaguebearerEvents.cs
+++ b/TownOfUs/Events/Neutral/PlaguebearerEvents.cs
@@ -54,7 +54,8 @@ public static class PlaguebearerEvents
         PlaguebearerRole.RpcCheckInfected(source, target);
 
         if (target.Data.Role is PlaguebearerRole &&
-            !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+            !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence &&
+            !PlaguebearerRole.InteractionWillTransform(target, source))
         {
             PestilenceRole.RpcHorsemanSensed(target);
         }

--- a/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
+++ b/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
@@ -4,9 +4,6 @@ using TownOfUs.Utilities;
 
 namespace TownOfUs.Modifiers.Neutral;
 
-// Applied to anyone who interacts with the Pestilence while Legacy Mode is off.
-// Only visible to the Pestilence (see PlayerRoleTextExtensions.UpdateStatusSymbols).
-// Killing a marked player resets the Pestilence's kill cooldown to 0 (chain kill).
 public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
 {
     public override string ModifierName => "Pestilence Stack";
@@ -18,7 +15,6 @@ public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
     {
         base.OnActivate();
 
-        // Flash the Pestilence's own screen so they know someone just interacted with them.
         if (PlayerControl.LocalPlayer.PlayerId == PestilenceId)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
@@ -27,7 +23,6 @@ public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
 
     public override void OnDeath(DeathReason reason)
     {
-        // The stack is consumed when the marked player dies (also clears the name symbol).
         ModifierComponent!.RemoveModifier(this);
     }
 }

--- a/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
+++ b/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
@@ -1,4 +1,6 @@
 using MiraAPI.Modifiers;
+using Reactor.Utilities;
+using TownOfUs.Utilities;
 
 namespace TownOfUs.Modifiers.Neutral;
 
@@ -11,4 +13,21 @@ public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
     public override bool HideOnUi => true;
 
     public byte PestilenceId { get; } = pestilenceId;
+
+    public override void OnActivate()
+    {
+        base.OnActivate();
+
+        // Flash the Pestilence's own screen so they know someone just interacted with them.
+        if (PlayerControl.LocalPlayer.PlayerId == PestilenceId)
+        {
+            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
+        }
+    }
+
+    public override void OnDeath(DeathReason reason)
+    {
+        // The stack is consumed when the marked player dies (also clears the name symbol).
+        ModifierComponent!.RemoveModifier(this);
+    }
 }

--- a/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
+++ b/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
@@ -1,6 +1,4 @@
 using MiraAPI.Modifiers;
-using Reactor.Utilities;
-using TownOfUs.Utilities;
 
 namespace TownOfUs.Modifiers.Neutral;
 
@@ -10,16 +8,6 @@ public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
     public override bool HideOnUi => true;
 
     public byte PestilenceId { get; } = pestilenceId;
-
-    public override void OnActivate()
-    {
-        base.OnActivate();
-
-        if (PlayerControl.LocalPlayer.PlayerId == PestilenceId)
-        {
-            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
-        }
-    }
 
     public override void OnDeath(DeathReason reason)
     {

--- a/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
+++ b/TownOfUs/Modifiers/Neutral/PestilenceStackModifier.cs
@@ -1,0 +1,14 @@
+using MiraAPI.Modifiers;
+
+namespace TownOfUs.Modifiers.Neutral;
+
+// Applied to anyone who interacts with the Pestilence while Legacy Mode is off.
+// Only visible to the Pestilence (see PlayerRoleTextExtensions.UpdateStatusSymbols).
+// Killing a marked player resets the Pestilence's kill cooldown to 0 (chain kill).
+public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
+{
+    public override string ModifierName => "Pestilence Stack";
+    public override bool HideOnUi => true;
+
+    public byte PestilenceId { get; } = pestilenceId;
+}

--- a/TownOfUs/Modifiers/Neutral/TerminalPestilenceModifier.cs
+++ b/TownOfUs/Modifiers/Neutral/TerminalPestilenceModifier.cs
@@ -2,9 +2,9 @@ using MiraAPI.Modifiers;
 
 namespace TownOfUs.Modifiers.Neutral;
 
-public sealed class PestilenceStackModifier(byte pestilenceId) : BaseModifier
+public sealed class TerminalPestilenceModifier(byte pestilenceId) : BaseModifier
 {
-    public override string ModifierName => "Pestilence Stack";
+    public override string ModifierName => "Terminal Pestilence";
     public override bool HideOnUi => true;
 
     public byte PestilenceId { get; } = pestilenceId;

--- a/TownOfUs/Modifiers/UnstoppableModifier.cs
+++ b/TownOfUs/Modifiers/UnstoppableModifier.cs
@@ -1,0 +1,9 @@
+using MiraAPI.Modifiers;
+
+namespace TownOfUs.Modifiers;
+
+public sealed class UnstoppableModifier : BaseModifier
+{
+    public override string ModifierName => "Unstoppable";
+    public override bool HideOnUi => true;
+}

--- a/TownOfUs/Options/Roles/Neutral/PlaguebearerOptions.cs
+++ b/TownOfUs/Options/Roles/Neutral/PlaguebearerOptions.cs
@@ -16,12 +16,9 @@ public sealed class PlaguebearerOptions : AbstractOptionGroup<PlaguebearerRole>
     [ModdedNumberOption("TouOptionPlaguebearerInfectCooldown", 5f, 120f, 2.5f, MiraNumberSuffixes.Seconds)]
     public float InfectCooldown { get; set; } = 25f;
 
-    // Legacy Mode reverts Pestilence to its original behavior (interactions instantly kill,
-    // and the announcement becomes an optional toggle again). Off = new "stack" rework is default.
     [ModdedToggleOption("TouOptionPlaguebearerLegacyMode")]
     public bool LegacyPestilence { get; set; } = false;
 
-    // Only shown in Legacy Mode. When Legacy Mode is off, the transformation is always announced.
     public ModdedToggleOption AnnouncePest { get; set; } = new("TouOptionPlaguebearerAnnounceTransformation", true)
     {
         Visible = () => OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence

--- a/TownOfUs/Options/Roles/Neutral/PlaguebearerOptions.cs
+++ b/TownOfUs/Options/Roles/Neutral/PlaguebearerOptions.cs
@@ -1,5 +1,6 @@
 using MiraAPI.GameOptions;
 using MiraAPI.GameOptions.Attributes;
+using MiraAPI.GameOptions.OptionTypes;
 using MiraAPI.Utilities;
 using TownOfUs.Roles.Neutral;
 
@@ -15,8 +16,16 @@ public sealed class PlaguebearerOptions : AbstractOptionGroup<PlaguebearerRole>
     [ModdedNumberOption("TouOptionPlaguebearerInfectCooldown", 5f, 120f, 2.5f, MiraNumberSuffixes.Seconds)]
     public float InfectCooldown { get; set; } = 25f;
 
-    [ModdedToggleOption("TouOptionPlaguebearerAnnounceTransformation")]
-    public bool AnnouncePest { get; set; } = true;
+    // Legacy Mode reverts Pestilence to its original behavior (interactions instantly kill,
+    // and the announcement becomes an optional toggle again). Off = new "stack" rework is default.
+    [ModdedToggleOption("TouOptionPlaguebearerLegacyMode")]
+    public bool LegacyPestilence { get; set; } = false;
+
+    // Only shown in Legacy Mode. When Legacy Mode is off, the transformation is always announced.
+    public ModdedToggleOption AnnouncePest { get; set; } = new("TouOptionPlaguebearerAnnounceTransformation", true)
+    {
+        Visible = () => OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence
+    };
 
     [ModdedNumberOption("TouOptionPlaguebearerPestilenceKillCooldown", 5f, 120f, 2.5f, MiraNumberSuffixes.Seconds)]
     public float PestKillCooldown { get; set; } = 25f;

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2118,9 +2118,12 @@
   <!-- Pestilence Wiki / Description -->
   <string name="TouRolePestilence">Pestilence</string>
   <string name="TouRolePestilenceIntroBlurb">Horseman of the Apocalypse!</string>
-  <string name="TouRolePestilenceTabDescription">Kill everyone in your path that interacts with you!</string>
+  <string name="TouRolePestilenceTabDescription">Mark those who interact with you, then hunt them down with unstoppable attacks!</string>
+  <string name="TouRolePestilenceTabDescriptionLegacy">Kill everyone in your path that interacts with you!</string>
   <string name="TouRolePestilenceYouAreText">You Are</string>
   <string name="TouRolePestilenceWikiDescription">The Pestilence is a Neutral Killing role that can kill and is invincible to everything but being exiled or guessing incorrectly. They win by being the last killer alive.</string>
+  <string name="TouRolePestilenceWikiAddition"> Anyone who interacts with them becomes marked, and their attacks cannot be stopped by any protection. Killing a marked player instantly resets their kill cooldown, letting them chain kills.</string>
+  <string name="TouRolePestilenceWikiAdditionLegacy"> Anyone who interacts with them is killed instantly.</string>
   <string name="TouRolePestilenceMessageTitle">Pestilence Warning</string>
   <string name="TouRolePestilenceAnnounceMessage">A deadly plague has consumed the Crew.\%nl\%\%role\%, Horseman of the Apocalypse, has emerged!</string>
   <!-- Spectre -->
@@ -2144,6 +2147,8 @@
   <string name="TouRolePlaguebearerTabInfectCounter">Players Left To Infect: \%count\%</string>
   <string name="TouRolePlaguebearerTabInfectedInfo">Players Infected:</string>
   <string name="TouRolePlaguebearerWikiDescription">The Plaguebearer is a Neutral Killing role that needs to infect all other players to turn into the Pestilence.</string>
+  <string name="TouRolePlaguebearerWikiAddition"> Once transformed, the Pestilence marks anyone who interacts with them and kills through any protection with unstoppable attacks.</string>
+  <string name="TouRolePlaguebearerWikiAdditionLegacy"> Once transformed, the Pestilence instantly kills anyone who interacts with them.</string>
   <string name="TouRolePlaguebearerInfect">Infect</string>
   <string name="TouRolePlaguebearerInfectWikiDescription">Infect a player, causing them to be infected. When an infected player or dead body interacts or gets interacted with, the infection will spread to the interacted/interacting player.</string>
   <!-- Rewritten for clarity and grammar issues -->

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2118,11 +2118,11 @@
   <!-- Pestilence Wiki / Description -->
   <string name="TouRolePestilence">Pestilence</string>
   <string name="TouRolePestilenceIntroBlurb">Horseman of the Apocalypse!</string>
-  <string name="TouRolePestilenceTabDescription">Inflict Terminal Pestilence on anyone who interacts with you. Your attacks are unstoppable.</string>
+  <string name="TouRolePestilenceTabDescription">Inflict Terminal Pestilence on\%nl\%anyone who interacts with you.\%nl\%Your attacks are unstoppable.</string>
   <string name="TouRolePestilenceTabDescriptionLegacy">Kill everyone in your path that interacts with you!</string>
   <string name="TouRolePestilenceYouAreText">You Are</string>
   <string name="TouRolePestilenceWikiDescription">The Pestilence is a Neutral Killing role that can kill and is invincible to everything but being exiled or guessing incorrectly. They win by being the last killer alive.</string>
-  <string name="TouRolePestilenceWikiAddition"> Anyone who interacts with them contracts Terminal Pestilence. Their attacks are unstoppable, killing through any shield. Killing an afflicted player reduces the Pestilence's next kill cooldown to zero.</string>
+  <string name="TouRolePestilenceWikiAddition"> Anyone who interacts with them contracts Terminal Pestilence, and killing an afflicted player reduces the Pestilence's next kill cooldown to zero. The Pestilence's attacks are unstoppable, killing through any shield.</string>
   <string name="TouRolePestilenceWikiAdditionLegacy"> Anyone who interacts with them is killed instantly.</string>
   <string name="TouRolePestilenceMessageTitle">Pestilence Warning</string>
   <string name="TouRolePestilenceAnnounceMessage">A deadly plague has consumed the Crew.\%nl\%\%role\%, Horseman of the Apocalypse, has emerged!</string>

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2152,6 +2152,7 @@
   <string name="TouOptionPlaguebearerInstantPesti">Instant Pestilence Chance</string>
   <string name="TouOptionPlaguebearerInfectCooldown">Infect Cooldown</string>
   <string name="TouOptionPlaguebearerAnnounceTransformation">Announce Pestilence Transformation</string>
+  <string name="TouOptionPlaguebearerLegacyMode">Legacy Mode</string>
   <string name="TouOptionPlaguebearerPestilenceKillCooldown">Pestilence Kill Cooldown</string>
   <string name="TouOptionPlaguebearerPestilenceCanVent">Pestilence Can Vent</string>
   <!-- Soul Collector -->

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2118,7 +2118,7 @@
   <!-- Pestilence Wiki / Description -->
   <string name="TouRolePestilence">Pestilence</string>
   <string name="TouRolePestilenceIntroBlurb">Horseman of the Apocalypse!</string>
-  <string name="TouRolePestilenceTabDescription">Inflict Terminal Pestilence on\%nl\%anyone who interacts with you.\%nl\%Your attacks are unstoppable.</string>
+  <string name="TouRolePestilenceTabDescription">Inflict Terminal Pestilence on anyone who interacts with you.\%nl\%Your attacks are unstoppable.</string>
   <string name="TouRolePestilenceTabDescriptionLegacy">Kill everyone in your path that interacts with you!</string>
   <string name="TouRolePestilenceYouAreText">You Are</string>
   <string name="TouRolePestilenceWikiDescription">The Pestilence is a Neutral Killing role that can kill and is invincible to everything but being exiled or guessing incorrectly. They win by being the last killer alive.</string>

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2118,11 +2118,11 @@
   <!-- Pestilence Wiki / Description -->
   <string name="TouRolePestilence">Pestilence</string>
   <string name="TouRolePestilenceIntroBlurb">Horseman of the Apocalypse!</string>
-  <string name="TouRolePestilenceTabDescription">Mark those who interact with you, then hunt them down with unstoppable attacks!</string>
+  <string name="TouRolePestilenceTabDescription">Inflict Terminal Pestilence on anyone who interacts with you. Your attacks are unstoppable.</string>
   <string name="TouRolePestilenceTabDescriptionLegacy">Kill everyone in your path that interacts with you!</string>
   <string name="TouRolePestilenceYouAreText">You Are</string>
   <string name="TouRolePestilenceWikiDescription">The Pestilence is a Neutral Killing role that can kill and is invincible to everything but being exiled or guessing incorrectly. They win by being the last killer alive.</string>
-  <string name="TouRolePestilenceWikiAddition"> Anyone who interacts with them becomes marked, and their attacks cannot be stopped by any protection. Killing a marked player instantly resets their kill cooldown, letting them chain kills.</string>
+  <string name="TouRolePestilenceWikiAddition"> Anyone who interacts with them contracts Terminal Pestilence. Their attacks are unstoppable, killing through any shield. Killing an afflicted player reduces the Pestilence's next kill cooldown to zero.</string>
   <string name="TouRolePestilenceWikiAdditionLegacy"> Anyone who interacts with them is killed instantly.</string>
   <string name="TouRolePestilenceMessageTitle">Pestilence Warning</string>
   <string name="TouRolePestilenceAnnounceMessage">A deadly plague has consumed the Crew.\%nl\%\%role\%, Horseman of the Apocalypse, has emerged!</string>
@@ -2147,7 +2147,7 @@
   <string name="TouRolePlaguebearerTabInfectCounter">Players Left To Infect: \%count\%</string>
   <string name="TouRolePlaguebearerTabInfectedInfo">Players Infected:</string>
   <string name="TouRolePlaguebearerWikiDescription">The Plaguebearer is a Neutral Killing role that needs to infect all other players to turn into the Pestilence.</string>
-  <string name="TouRolePlaguebearerWikiAddition"> Once transformed, the Pestilence marks anyone who interacts with them and kills through any protection with unstoppable attacks.</string>
+  <string name="TouRolePlaguebearerWikiAddition"> Once transformed, the Pestilence inflicts Terminal Pestilence on anyone who interacts with them. It cannot be cleansed, and killing an afflicted target lets the Pestilence immediately kill again. The Pestilence's attacks are unstoppable and ignore shields.</string>
   <string name="TouRolePlaguebearerWikiAdditionLegacy"> Once transformed, the Pestilence instantly kills anyone who interacts with them.</string>
   <string name="TouRolePlaguebearerInfect">Infect</string>
   <string name="TouRolePlaguebearerInfectWikiDescription">Infect a player, causing them to be infected. When an infected player or dead body interacts or gets interacted with, the infection will spread to the interacted/interacting player.</string>

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateProtective/MirrorcasterRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateProtective/MirrorcasterRole.cs
@@ -13,6 +13,7 @@ using TownOfUs.Modifiers.Crewmate;
 using TownOfUs.Modules;
 using TownOfUs.Options;
 using TownOfUs.Options.Roles.Crewmate;
+using TownOfUs.Roles.Neutral;
 using UnityEngine;
 
 namespace TownOfUs.Roles.Crewmate;
@@ -171,6 +172,7 @@ public sealed class MirrorcasterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITou
         }
 
         role?.SetProtectedPlayer(target);
+        PlaguebearerRole.HandleHorsemanInteraction(mc, target);
     }
 
     [MethodRpc((uint)TownOfUsRpc.ClearMagicMirror)]

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
@@ -189,54 +189,14 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
             mercenary!.AddPayment();
         }
 
-        if (play1.TryGetModifier<InvulnerabilityModifier>(out var invic) && invic.AttackAllInteractions)
+        if (PestilenceRole.HandlePestInteraction(transporter, play1))
         {
-            if (play1.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
-            {
-                if (transporter.AmOwner)
-                {
-                    if (!transporter.HasModifier<PestilenceStackModifier>())
-                    {
-                        transporter.RpcAddModifier<PestilenceStackModifier>(play1.PlayerId);
-                    }
-
-                    PestilenceRole.RpcHorsemanSensed(play1);
-                }
-            }
-            else
-            {
-                if (transporter.AmOwner)
-                {
-                    play1.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
-                }
-
-                return;
-            }
+            return;
         }
 
-        if (play2.TryGetModifier<InvulnerabilityModifier>(out var invic2) && invic2.AttackAllInteractions)
+        if (PestilenceRole.HandlePestInteraction(transporter, play2))
         {
-            if (play2.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
-            {
-                if (transporter.AmOwner)
-                {
-                    if (!transporter.HasModifier<PestilenceStackModifier>())
-                    {
-                        transporter.RpcAddModifier<PestilenceStackModifier>(play2.PlayerId);
-                    }
-
-                    PestilenceRole.RpcHorsemanSensed(play2);
-                }
-            }
-            else
-            {
-                if (transporter.AmOwner)
-                {
-                    play2.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
-                }
-
-                return;
-            }
+            return;
         }
 
         if (play1.HasModifier<VeteranAlertModifier>())

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
@@ -169,12 +169,12 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
 
         if (transporter.AmOwner && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
         {
-            if (play1.Data.Role is PlaguebearerRole)
+            if (play1.Data.Role is PlaguebearerRole && !PlaguebearerRole.InteractionWillTransform(play1, transporter))
             {
                 PestilenceRole.RpcHorsemanSensed(play1);
             }
 
-            if (play2.Data.Role is PlaguebearerRole)
+            if (play2.Data.Role is PlaguebearerRole && !PlaguebearerRole.InteractionWillTransform(play2, transporter))
             {
                 PestilenceRole.RpcHorsemanSensed(play2);
             }

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
@@ -191,9 +191,9 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
 
         if (play1.TryGetModifier<InvulnerabilityModifier>(out var invic) && invic.AttackAllInteractions)
         {
-            if (transporter.AmOwner)
+            if (play1.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
             {
-                if (play1.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+                if (transporter.AmOwner)
                 {
                     if (!transporter.HasModifier<PestilenceStackModifier>())
                     {
@@ -202,20 +202,23 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
 
                     PestilenceRole.RpcHorsemanSensed(play1);
                 }
-                else
+            }
+            else
+            {
+                if (transporter.AmOwner)
                 {
                     play1.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
                 }
-            }
 
-            return;
+                return;
+            }
         }
 
         if (play2.TryGetModifier<InvulnerabilityModifier>(out var invic2) && invic2.AttackAllInteractions)
         {
-            if (transporter.AmOwner)
+            if (play2.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
             {
-                if (play2.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+                if (transporter.AmOwner)
                 {
                     if (!transporter.HasModifier<PestilenceStackModifier>())
                     {
@@ -224,13 +227,16 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
 
                     PestilenceRole.RpcHorsemanSensed(play2);
                 }
-                else
+            }
+            else
+            {
+                if (transporter.AmOwner)
                 {
                     play2.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
                 }
-            }
 
-            return;
+                return;
+            }
         }
 
         if (play1.HasModifier<VeteranAlertModifier>())

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateSupport/TransporterRole.cs
@@ -1,5 +1,6 @@
 ﻿using Il2CppInterop.Runtime.Attributes;
 using MiraAPI.Events;
+using MiraAPI.GameOptions;
 using MiraAPI.Hud;
 using MiraAPI.Modifiers;
 using MiraAPI.Networking;
@@ -18,6 +19,7 @@ using TownOfUs.Modifiers.Game.Universal;
 using TownOfUs.Modifiers.Impostor;
 using TownOfUs.Modifiers.Neutral;
 using TownOfUs.Modules;
+using TownOfUs.Options.Roles.Neutral;
 using TownOfUs.Roles.Neutral;
 using UnityEngine;
 
@@ -165,6 +167,19 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
             transporter.AddModifier<PlaguebearerInfectedModifier>(infectedplayer2.PlagueBearerId);
         }
 
+        if (transporter.AmOwner && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+        {
+            if (play1.Data.Role is PlaguebearerRole)
+            {
+                PestilenceRole.RpcHorsemanSensed(play1);
+            }
+
+            if (play2.Data.Role is PlaguebearerRole)
+            {
+                PestilenceRole.RpcHorsemanSensed(play2);
+            }
+        }
+
         LookoutEvents.CheckForLookoutWatched(transporter, play1);
         LookoutEvents.CheckForLookoutWatched(transporter, play2);
 
@@ -178,7 +193,19 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
         {
             if (transporter.AmOwner)
             {
-                play1.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
+                if (play1.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+                {
+                    if (!transporter.HasModifier<PestilenceStackModifier>())
+                    {
+                        transporter.RpcAddModifier<PestilenceStackModifier>(play1.PlayerId);
+                    }
+
+                    PestilenceRole.RpcHorsemanSensed(play1);
+                }
+                else
+                {
+                    play1.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
+                }
             }
 
             return;
@@ -188,7 +215,19 @@ public sealed class TransporterRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITown
         {
             if (transporter.AmOwner)
             {
-                play2.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
+                if (play2.Data.Role is PestilenceRole && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+                {
+                    if (!transporter.HasModifier<PestilenceStackModifier>())
+                    {
+                        transporter.RpcAddModifier<PestilenceStackModifier>(play2.PlayerId);
+                    }
+
+                    PestilenceRole.RpcHorsemanSensed(play2);
+                }
+                else
+                {
+                    play2.RpcCustomMurder(transporter, MeetingCheck.OutsideMeeting);
+                }
             }
 
             return;

--- a/TownOfUs/Roles/Classic/Impostor/ImpostorPower/PuppeteerRole.cs
+++ b/TownOfUs/Roles/Classic/Impostor/ImpostorPower/PuppeteerRole.cs
@@ -11,6 +11,7 @@ using TownOfUs.Modifiers.Impostor;
 using TownOfUs.Modules.ControlSystem;
 using TownOfUs.Options.Roles.Impostor;
 using TownOfUs.Patches.ControlSystem;
+using TownOfUs.Roles.Neutral;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -197,6 +198,8 @@ public sealed class PuppeteerRole(IntPtr cppPtr) : ImpostorRole(cppPtr), ITownOf
         {
             target.AddModifier<PuppeteerControlModifier>(puppeteer);
         }
+
+        PlaguebearerRole.HandleHorsemanInteraction(puppeteer, target);
 
         if (target.inVent)
         {

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -202,7 +202,7 @@ public sealed class PestilenceRole(IntPtr cppPtr)
             Player.AddModifier<UnstoppableModifier>();
         }
 
-        if (Player.AmOwner && !plagueOpts.LegacyPestilence)
+        if (Player.AmOwner && !plagueOpts.LegacyPestilence && !IntroCutscene.Instance)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
         }

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Text;
 using AmongUs.GameOptions;
 using HarmonyLib;
@@ -140,17 +139,6 @@ public sealed class PestilenceRole(IntPtr cppPtr)
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
         }
         else if (player.Data.Role is PlaguebearerRole)
-        {
-            Coroutines.Start(CoHorsemanSensedFlash(player));
-        }
-    }
-
-    private static IEnumerator CoHorsemanSensedFlash(PlayerControl player)
-    {
-        yield return new WaitForSeconds(0.15f);
-
-        // skip the flash if this interaction just turned the Plaguebearer into Pestilence
-        if (player && player.Data.Role is PlaguebearerRole)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Plaguebearer));
         }

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using Il2CppInterop.Runtime.Attributes;
 using MiraAPI.GameOptions;
 using MiraAPI.Modifiers;
+using MiraAPI.Networking;
 using MiraAPI.Patches.Stubs;
 using MiraAPI.Roles;
 using MiraAPI.Utilities;
@@ -141,6 +142,37 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Plaguebearer));
         }
+    }
+
+    public static bool HandlePestInteraction(PlayerControl interactor, PlayerControl pest)
+    {
+        if (!pest.TryGetModifier<InvulnerabilityModifier>(out var invic) || !invic.AttackAllInteractions ||
+            pest.Data.Role is not PestilenceRole)
+        {
+            return false;
+        }
+
+        if (OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+        {
+            if (interactor.AmOwner)
+            {
+                pest.RpcCustomMurder(interactor, MeetingCheck.OutsideMeeting);
+            }
+
+            return true;
+        }
+
+        if (interactor.AmOwner)
+        {
+            if (!interactor.HasModifier<PestilenceStackModifier>())
+            {
+                interactor.RpcAddModifier<PestilenceStackModifier>(pest.PlayerId);
+            }
+
+            RpcHorsemanSensed(pest);
+        }
+
+        return false;
     }
 
     public override void Initialize(PlayerControl player)

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -192,6 +192,11 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         var plagueOpts = OptionGroupSingleton<PlaguebearerOptions>.Instance;
         Announced = plagueOpts.LegacyPestilence && !plagueOpts.AnnouncePest.Value;
 
+        if (!plagueOpts.LegacyPestilence && !Player.HasModifier<UnstoppableModifier>())
+        {
+            Player.AddModifier<UnstoppableModifier>();
+        }
+
         if (Player.AmOwner && !plagueOpts.LegacyPestilence)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -123,6 +123,11 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         if (player.Data.Role is not PestilenceRole)
         {
             player.ChangeRole(RoleId.Get<PestilenceRole>());
+
+            if (player.AmOwner && !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+            {
+                Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
+            }
         }
     }
 
@@ -200,11 +205,6 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         if (!plagueOpts.LegacyPestilence && !Player.HasModifier<UnstoppableModifier>())
         {
             Player.AddModifier<UnstoppableModifier>();
-        }
-
-        if (Player.AmOwner && !plagueOpts.LegacyPestilence && !IntroCutscene.Instance)
-        {
-            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
         }
     }
 

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -133,7 +133,9 @@ public sealed class PestilenceRole(IntPtr cppPtr)
             HudManager.Instance.ImpostorVentButton.buttonLabelText.SetOutlineColor(TownOfUsColors.Pestilence);
         }
 
-        Announced = !OptionGroupSingleton<PlaguebearerOptions>.Instance.AnnouncePest;
+        var plagueOpts = OptionGroupSingleton<PlaguebearerOptions>.Instance;
+        // In Legacy Mode the announcement respects the toggle; otherwise it is always announced.
+        Announced = plagueOpts.LegacyPestilence && !plagueOpts.AnnouncePest.Value;
     }
 
     public override void Deinitialize(PlayerControl targetPlayer)

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -9,6 +9,7 @@ using MiraAPI.Roles;
 using MiraAPI.Utilities;
 using Reactor.Networking.Attributes;
 using Reactor.Networking.Rpc;
+using Reactor.Utilities;
 using Reactor.Utilities.Extensions;
 using TownOfUs.Modifiers;
 using TownOfUs.Modifiers.Neutral;
@@ -119,6 +120,29 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         }
     }
 
+    [MethodRpc((uint)TownOfUsRpc.HorsemanSensed)]
+    public static void RpcHorsemanSensed(PlayerControl player)
+    {
+        if (LobbyBehaviour.Instance)
+        {
+            MiscUtils.RunAnticheatWarning(player);
+            return;
+        }
+        if (!player.AmOwner)
+        {
+            return;
+        }
+
+        if (player.Data.Role is PestilenceRole)
+        {
+            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
+        }
+        else if (player.Data.Role is PlaguebearerRole)
+        {
+            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Plaguebearer));
+        }
+    }
+
     public override void Initialize(PlayerControl player)
     {
         RoleBehaviourStubs.Initialize(this, player);
@@ -135,6 +159,11 @@ public sealed class PestilenceRole(IntPtr cppPtr)
 
         var plagueOpts = OptionGroupSingleton<PlaguebearerOptions>.Instance;
         Announced = plagueOpts.LegacyPestilence && !plagueOpts.AnnouncePest.Value;
+
+        if (Player.AmOwner && !plagueOpts.LegacyPestilence)
+        {
+            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
+        }
     }
 
     public override void Deinitialize(PlayerControl targetPlayer)

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -134,7 +134,6 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         }
 
         var plagueOpts = OptionGroupSingleton<PlaguebearerOptions>.Instance;
-        // In Legacy Mode the announcement respects the toggle; otherwise it is always announced.
         Announced = plagueOpts.LegacyPestilence && !plagueOpts.AnnouncePest.Value;
     }
 

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -42,12 +42,17 @@ public sealed class PestilenceRole(IntPtr cppPtr)
     public string LocaleKey => "Pestilence";
     public string RoleName => TouLocale.Get($"TouRole{LocaleKey}");
     public string RoleDescription => TouLocale.GetParsed($"TouRole{LocaleKey}IntroBlurb");
-    public string RoleLongDescription => TouLocale.GetParsed($"TouRole{LocaleKey}TabDescription");
+    public string RoleLongDescription => OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence
+        ? TouLocale.GetParsed($"TouRole{LocaleKey}TabDescriptionLegacy")
+        : TouLocale.GetParsed($"TouRole{LocaleKey}TabDescription");
 
     public string GetAdvancedDescription()
     {
         return
             TouLocale.GetParsed($"TouRole{LocaleKey}WikiDescription") +
+            TouLocale.GetParsed(OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence
+                ? $"TouRole{LocaleKey}WikiAdditionLegacy"
+                : $"TouRole{LocaleKey}WikiAddition") +
             MiscUtils.AppendOptionsText(GetType());
     }
 

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -169,9 +169,9 @@ public sealed class PestilenceRole(IntPtr cppPtr)
 
         if (interactor.AmOwner)
         {
-            if (!interactor.HasModifier<PestilenceStackModifier>())
+            if (!interactor.HasModifier<TerminalPestilenceModifier>())
             {
-                interactor.RpcAddModifier<PestilenceStackModifier>(pest.PlayerId);
+                interactor.RpcAddModifier<TerminalPestilenceModifier>(pest.PlayerId);
             }
 
             RpcHorsemanSensed(pest);

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text;
 using AmongUs.GameOptions;
 using HarmonyLib;
@@ -138,7 +139,18 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
         }
-        else if (player.Data.Role is PlaguebearerRole plaguebearer && !plaguebearer.IsInfectionComplete())
+        else if (player.Data.Role is PlaguebearerRole)
+        {
+            Coroutines.Start(CoHorsemanSensedFlash(player));
+        }
+    }
+
+    private static IEnumerator CoHorsemanSensedFlash(PlayerControl player)
+    {
+        yield return new WaitForSeconds(0.15f);
+
+        // skip the flash if this interaction just turned the Plaguebearer into Pestilence
+        if (player && player.Data.Role is PlaguebearerRole)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Plaguebearer));
         }

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PestilenceRole.cs
@@ -138,7 +138,7 @@ public sealed class PestilenceRole(IntPtr cppPtr)
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Pestilence));
         }
-        else if (player.Data.Role is PlaguebearerRole)
+        else if (player.Data.Role is PlaguebearerRole plaguebearer && !plaguebearer.IsInfectionComplete())
         {
             Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Plaguebearer));
         }

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
@@ -197,6 +197,26 @@ public sealed class PlaguebearerRole(IntPtr cppPtr)
         }
     }
 
+    public static bool InteractionWillTransform(PlayerControl plaguebearer, PlayerControl interactor)
+    {
+        if (plaguebearer.Data.Role is not PlaguebearerRole)
+        {
+            return false;
+        }
+
+        var alive = Helpers.GetAlivePlayers();
+
+        if (MeetingHud.Instance && alive.Count <= 2)
+        {
+            return false;
+        }
+
+        var infected = alive.Count(x => x != plaguebearer && (x == interactor ||
+            (x.TryGetModifier<PlaguebearerInfectedModifier>(out var mod) && mod.PlagueBearerId == plaguebearer.PlayerId)));
+
+        return infected >= alive.Count - 1;
+    }
+
     [MethodRpc((uint)TownOfUsRpc.CheckInfected)]
     public static void RpcCheckInfected(PlayerControl source, PlayerControl target)
     {
@@ -213,7 +233,8 @@ public sealed class PlaguebearerRole(IntPtr cppPtr)
         CheckInfected(interactor, target);
 
         if (target.Data.Role is PlaguebearerRole && interactor.AmOwner &&
-            !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+            !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence &&
+            !InteractionWillTransform(target, interactor))
         {
             PestilenceRole.RpcHorsemanSensed(target);
         }

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
@@ -207,4 +207,17 @@ public sealed class PlaguebearerRole(IntPtr cppPtr)
         }
         CheckInfected(source, target);
     }
+
+    public static void HandleHorsemanInteraction(PlayerControl interactor, PlayerControl target)
+    {
+        CheckInfected(interactor, target);
+
+        if (target.Data.Role is PlaguebearerRole && interactor.AmOwner &&
+            !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence)
+        {
+            PestilenceRole.RpcHorsemanSensed(target);
+        }
+
+        PestilenceRole.HandlePestInteraction(interactor, target);
+    }
 }

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
@@ -64,6 +64,9 @@ public sealed class PlaguebearerRole(IntPtr cppPtr)
     {
         return
             TouLocale.GetParsed($"TouRole{LocaleKey}WikiDescription") +
+            TouLocale.GetParsed(OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence
+                ? $"TouRole{LocaleKey}WikiAdditionLegacy"
+                : $"TouRole{LocaleKey}WikiAddition") +
             MiscUtils.AppendOptionsText(GetType());
     }
 

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
@@ -40,23 +40,17 @@ public sealed class PlaguebearerRole(IntPtr cppPtr)
             return;
         }
 
-        if (IsInfectionComplete())
+        var allInfected =
+            ModifierUtils.GetPlayersWithModifier<PlaguebearerInfectedModifier>([HideFromIl2Cpp](x) => !x.Player.HasDied() && x.PlagueBearerId == Player.PlayerId && !x.Player.AmOwner);
+
+        if (allInfected.Count() >= Helpers.GetAlivePlayers().Count - 1 &&
+            (!MeetingHud.Instance || Helpers.GetAlivePlayers().Count > 2))
         {
             PestilenceRole.RpcTriggerPestilence(PlayerControl.LocalPlayer);
 
             CustomButtonSingleton<PestilenceKillButton>.Instance.SetTimer(OptionGroupSingleton<PlaguebearerOptions>
                 .Instance.PestKillCooldown);
         }
-    }
-
-    [HideFromIl2Cpp]
-    public bool IsInfectionComplete()
-    {
-        var allInfected =
-            ModifierUtils.GetPlayersWithModifier<PlaguebearerInfectedModifier>([HideFromIl2Cpp](x) => !x.Player.HasDied() && x.PlagueBearerId == Player.PlayerId && !x.Player.AmOwner);
-
-        return allInfected.Count() >= Helpers.GetAlivePlayers().Count - 1 &&
-            (!MeetingHud.Instance || Helpers.GetAlivePlayers().Count > 2);
     }
 
     public RoleBehaviour CrewVariant => RoleManager.Instance.GetRole((RoleTypes)RoleId.Get<AurialRole>());

--- a/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralKilling/PlaguebearerRole.cs
@@ -40,17 +40,23 @@ public sealed class PlaguebearerRole(IntPtr cppPtr)
             return;
         }
 
-        var allInfected =
-            ModifierUtils.GetPlayersWithModifier<PlaguebearerInfectedModifier>([HideFromIl2Cpp](x) => !x.Player.HasDied() && x.PlagueBearerId == Player.PlayerId && !x.Player.AmOwner);
-
-        if (allInfected.Count() >= Helpers.GetAlivePlayers().Count - 1 &&
-            (!MeetingHud.Instance || Helpers.GetAlivePlayers().Count > 2))
+        if (IsInfectionComplete())
         {
             PestilenceRole.RpcTriggerPestilence(PlayerControl.LocalPlayer);
 
             CustomButtonSingleton<PestilenceKillButton>.Instance.SetTimer(OptionGroupSingleton<PlaguebearerOptions>
                 .Instance.PestKillCooldown);
         }
+    }
+
+    [HideFromIl2Cpp]
+    public bool IsInfectionComplete()
+    {
+        var allInfected =
+            ModifierUtils.GetPlayersWithModifier<PlaguebearerInfectedModifier>([HideFromIl2Cpp](x) => !x.Player.HasDied() && x.PlagueBearerId == Player.PlayerId && !x.Player.AmOwner);
+
+        return allInfected.Count() >= Helpers.GetAlivePlayers().Count - 1 &&
+            (!MeetingHud.Instance || Helpers.GetAlivePlayers().Count > 2);
     }
 
     public RoleBehaviour CrewVariant => RoleManager.Instance.GetRole((RoleTypes)RoleId.Get<AurialRole>());

--- a/TownOfUs/TownOfUsRpc.cs
+++ b/TownOfUs/TownOfUsRpc.cs
@@ -137,4 +137,5 @@ public enum TownOfUsRpc : uint
     OfficerSyncBullets,
     SetUpCrewpostor,
     MisguessSummary,
+    HorsemanSensed,
 }

--- a/TownOfUs/Utilities/Extensions.cs
+++ b/TownOfUs/Utilities/Extensions.cs
@@ -20,12 +20,10 @@ using TownOfUs.Modules;
 using TownOfUs.Options;
 using TownOfUs.Options.Maps;
 using TownOfUs.Options.Modifiers.Alliance;
-using TownOfUs.Options.Roles.Neutral;
 using TownOfUs.Patches;
 using TownOfUs.Patches.Options;
 using TownOfUs.Roles;
 using TownOfUs.Roles.Impostor;
-using TownOfUs.Roles.Neutral;
 using TownOfUs.Utilities.Appearances;
 using UnityEngine;
 using UnityEngine.Events;
@@ -59,12 +57,6 @@ public static class Extensions
     public static bool IsRole<T>(this PlayerControl player) where T : RoleBehaviour
     {
         return player.Data?.Role is T;
-    }
-
-    public static bool IsUnstoppablePest(this PlayerControl player)
-    {
-        return player.Data?.Role is PestilenceRole &&
-               !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence;
     }
 
     public static bool IsLover(this PlayerControl player)

--- a/TownOfUs/Utilities/Extensions.cs
+++ b/TownOfUs/Utilities/Extensions.cs
@@ -20,10 +20,12 @@ using TownOfUs.Modules;
 using TownOfUs.Options;
 using TownOfUs.Options.Maps;
 using TownOfUs.Options.Modifiers.Alliance;
+using TownOfUs.Options.Roles.Neutral;
 using TownOfUs.Patches;
 using TownOfUs.Patches.Options;
 using TownOfUs.Roles;
 using TownOfUs.Roles.Impostor;
+using TownOfUs.Roles.Neutral;
 using TownOfUs.Utilities.Appearances;
 using UnityEngine;
 using UnityEngine.Events;
@@ -57,6 +59,12 @@ public static class Extensions
     public static bool IsRole<T>(this PlayerControl player) where T : RoleBehaviour
     {
         return player.Data?.Role is T;
+    }
+
+    public static bool IsUnstoppablePest(this PlayerControl player)
+    {
+        return player.Data?.Role is PestilenceRole &&
+               !OptionGroupSingleton<PlaguebearerOptions>.Instance.LegacyPestilence;
     }
 
     public static bool IsLover(this PlayerControl player)

--- a/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
+++ b/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
@@ -302,6 +302,12 @@ public static class PlayerRoleTextExtensions
             name += "<color=#FF4D00> Δ</color>";
         }
 
+        // Pestilence "stack" mark: shown only to the Pestilence, next to players who interacted with it.
+        if (player.HasModifier<PestilenceStackModifier>() && PlayerControl.LocalPlayer.IsRole<PestilenceRole>())
+        {
+            name += $" {TownOfUsColors.Pestilence.ToTextColor()}‡</color>";
+        }
+
         // This doesn't check for the role itself incase external mods make use of these functions
         if (player.HasModifier(PuppeteerControlledPredicate)
             || player.HasModifier(ParasiteOvertakenPredicate)

--- a/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
+++ b/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
@@ -302,7 +302,6 @@ public static class PlayerRoleTextExtensions
             name += "<color=#FF4D00> Δ</color>";
         }
 
-        // Pestilence "stack" mark: shown to the Pestilence, and to dead spectators (like the infect mark).
         if ((player.HasModifier<PestilenceStackModifier>() && PlayerControl.LocalPlayer.IsRole<PestilenceRole>())
             || (player.HasModifier<PestilenceStackModifier>() && isDead))
         {

--- a/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
+++ b/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
@@ -302,8 +302,8 @@ public static class PlayerRoleTextExtensions
             name += "<color=#FF4D00> Δ</color>";
         }
 
-        if ((player.HasModifier<PestilenceStackModifier>() && PlayerControl.LocalPlayer.IsRole<PestilenceRole>())
-            || (player.HasModifier<PestilenceStackModifier>() && isDead))
+        if ((player.HasModifier<TerminalPestilenceModifier>() && PlayerControl.LocalPlayer.IsRole<PestilenceRole>())
+            || (player.HasModifier<TerminalPestilenceModifier>() && isDead))
         {
             name += $" {TownOfUsColors.Pestilence.ToTextColor()}¥</color>";
         }

--- a/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
+++ b/TownOfUs/Utilities/PlayerRoleTextExtensions.cs
@@ -302,10 +302,11 @@ public static class PlayerRoleTextExtensions
             name += "<color=#FF4D00> Δ</color>";
         }
 
-        // Pestilence "stack" mark: shown only to the Pestilence, next to players who interacted with it.
-        if (player.HasModifier<PestilenceStackModifier>() && PlayerControl.LocalPlayer.IsRole<PestilenceRole>())
+        // Pestilence "stack" mark: shown to the Pestilence, and to dead spectators (like the infect mark).
+        if ((player.HasModifier<PestilenceStackModifier>() && PlayerControl.LocalPlayer.IsRole<PestilenceRole>())
+            || (player.HasModifier<PestilenceStackModifier>() && isDead))
         {
-            name += $" {TownOfUsColors.Pestilence.ToTextColor()}‡</color>";
+            name += $" {TownOfUsColors.Pestilence.ToTextColor()}¥</color>";
         }
 
         // This doesn't check for the role itself incase external mods make use of these functions


### PR DESCRIPTION
## Summary
Reworks the Plaguebearer and Pestilence and adds a **Legacy Mode** toggle to revert back to the original behavior.

## Non-Legacy behavior (New default)
-Interacting with the Pestilence now inflicts **Terminal Pestilence** on the interactor and flashes the Pestilence's screen, instead of instantly killing. (Note: Terminal Pestilence cannot be cleansed and **only** spreads via interacting with the Pestilence, it cannot be spread crew-to-crew like the Plaguebearer infection).
-Pestilence transformation announcement is now mandatory and no longer a setting.
-Killing a player afflicted with Terminal Pestilence resets the Pestilence's kill cooldown to 0, enabling chain kills.
-The Pestillence's attacks are now **unstoppable** with a new hidden unstoppable modifier that allows them to go through every protection (Medic / Cleric / Warden / Guardian Angel / Herbalist / Veteran alert, and the first death shield).
-The Plaguebearer gets a Plaguebearer colored screen flash when interacted with.
-Menu-based action interactions (Transporter, Mirrorcaster, Puppeteer) route through the shared interaction handlers so they count toward the line and flash correctly, this part the Mirrorcaster and Puppeteer interaction also works properly now Legacy Mode and spreads the infection correctly.
- Arsonist igniting a doused Pestilence directly is now killed.

## Legacy Mode (Toggle on)
-Restores to the original Plaguebeaerer and Pestilence and is completely unchanged, along with the transformation announcement option toggle.

## Misc
-Wiki and role-tab descriptions have been updated to match the new rework if Legacy Mode is set on False, if Legacy Mode is on True, it reflects the original Plaguebearer and Pestilence behavior.
- Adds `UnstoppableModifier` (so it's resusable for future roles :) ) and `TerminalPestilenceModifier` (the interaction mark)

## Testing
-Non-legacy: interacting with the Pestilence marks the interactor + flashes Pesti's screen; no instant death.
-Chain kill: works as intended, only works when killing Terminal Pestilence afflicted crewmates.
-Unstoppable attacks: work.
-Legacy Mode on: original still instant kill from interactions, no unstoppable attacks no screen flashes.
-Mirrorcaster and Puppeteer interactions properly infect now.
-Tested everything too many times to mention.