### PR TITLE
Officer tweaks

### DIFF
--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateKilling/OfficerLoadButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateKilling/OfficerLoadButton.cs
@@ -2,6 +2,7 @@
 using MiraAPI.GameOptions;
 using MiraAPI.Hud;
 using Reactor.Utilities;
+using TownOfUs.Events;
 using TownOfUs.Options.Roles.Crewmate;
 using TownOfUs.Roles.Crewmate;
 using UnityEngine;
@@ -14,20 +15,58 @@ public sealed class OfficerLoadButton : TownOfUsRoleButton<OfficerRole>
     public override BaseKeybind Keybind => Keybinds.SecondaryAction;
     public override Color TextOutlineColor => TownOfUsColors.Officer;
     public override float Cooldown => Math.Clamp(OptionGroupSingleton<OfficerOptions>.Instance.LoadCooldown.Value + MapCooldown, 5f, 120f);
+    public override float EffectDuration => Math.Clamp(OptionGroupSingleton<OfficerOptions>.Instance.LoadDelay.Value, 0.01f, 5f);
     public override int MaxUses => (int)OptionGroupSingleton<OfficerOptions>.Instance.MaxBulletsTotal;
     public override LoadableAsset<Sprite> Sprite => TouCrewAssets.OfficerLoadSprite;
     public static OfficerShootButton ShootButton => CustomButtonSingleton<OfficerShootButton>.Instance;
     public static int MaxLoadedBullets => (int)OptionGroupSingleton<OfficerOptions>.Instance.MaxBulletsAtOnce;
     public bool RecentlyLoadedBullet;
     public override bool UsableFirstRound => OptionGroupSingleton<OfficerOptions>.Instance.FirstRoundShooting;
+    private int _loadRound;
 
     public override bool CanUse()
     {
         return base.CanUse() && !ShootButton.FailedShot && ShootButton.LoadedBullets < MaxLoadedBullets;
     }
 
+    public override void ClickHandler()
+    {
+        if (!CanClick())
+        {
+            return;
+        }
+
+        OnClick();
+
+        if (HasEffect)
+        {
+            EffectActive = true;
+            Timer = EffectDuration;
+        }
+        else
+        {
+            Timer = Cooldown;
+        }
+    }
+
     protected override void OnClick()
     {
+        _loadRound = DeathEventHandlers.CurrentRound;
+    }
+
+    public override void OnEffectEnd()
+    {
+        if (MeetingHud.Instance || DeathEventHandlers.CurrentRound != _loadRound)
+        {
+            return;
+        }
+
+        UsesLeft--;
+        if (LimitedUses)
+        {
+            Button?.SetUsesRemaining(UsesLeft);
+        }
+
         ShootButton.TotalBullets--;
         ShootButton.LoadedBullets++;
         OfficerRole.RpcOfficerSyncBullets(PlayerControl.LocalPlayer, ShootButton.RoundsBeforeReset, ShootButton.TotalBullets, ShootButton.LoadedBullets);

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateKilling/OfficerLoadButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateKilling/OfficerLoadButton.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using MiraAPI.GameOptions;
 using MiraAPI.Hud;
+using MiraAPI.Utilities;
 using Reactor.Utilities;
 using TownOfUs.Events;
 using TownOfUs.Options.Roles.Crewmate;
@@ -65,6 +66,15 @@ public sealed class OfficerLoadButton : TownOfUsRoleButton<OfficerRole>
         if (LimitedUses)
         {
             Button?.SetUsesRemaining(UsesLeft);
+            TownOfUsColors.UseBasic = false;
+            if (TextOutlineColor != Color.clear)
+            {
+                SetTextOutline(TextOutlineColor);
+                Button?.usesRemainingSprite.color = TextOutlineColor;
+            }
+
+            TownOfUsColors.UseBasic = LocalSettingsTabSingleton<TownOfUsLocalRoleSettings>.Instance
+                .UseCrewmateTeamColorToggle.Value;
         }
 
         ShootButton.TotalBullets--;

--- a/TownOfUs/Events/Crewmate/OfficerEvents.cs
+++ b/TownOfUs/Events/Crewmate/OfficerEvents.cs
@@ -1,7 +1,11 @@
 ﻿using MiraAPI.Events;
+using MiraAPI.Events.Mira;
 using MiraAPI.Events.Vanilla.Gameplay;
+using MiraAPI.GameOptions;
 using MiraAPI.Hud;
 using TownOfUs.Buttons.Crewmate;
+using TownOfUs.Options.Roles.Crewmate;
+using TownOfUs.Roles.Crewmate;
 
 namespace TownOfUs.Events.Crewmate;
 
@@ -19,5 +23,23 @@ public static class OfficerEvents
         shootButton.TotalBullets = -1;
         shootButton.RoundsBeforeReset = 0;
         shootButton.LoadedBullets = 0;
+    }
+
+    [RegisterEvent]
+    public static void MiraButtonCancelledEventHandler(MiraButtonCancelledEvent @event)
+    {
+        if (@event.Button is not OfficerShootButton button)
+        {
+            return;
+        }
+
+        if (!OptionGroupSingleton<OfficerOptions>.Instance.BlockedShotConsumesBullet.Value || button.LoadedBullets <= 0)
+        {
+            return;
+        }
+
+        button.LoadedBullets--;
+        OfficerRole.RpcOfficerSyncBullets(PlayerControl.LocalPlayer, button.RoundsBeforeReset, button.TotalBullets,
+            button.LoadedBullets);
     }
 }

--- a/TownOfUs/Events/Crewmate/OfficerEvents.cs
+++ b/TownOfUs/Events/Crewmate/OfficerEvents.cs
@@ -28,7 +28,12 @@ public static class OfficerEvents
     [RegisterEvent]
     public static void MiraButtonCancelledEventHandler(MiraButtonCancelledEvent @event)
     {
-        if (@event.Button is not OfficerShootButton button)
+        if (@event.Button is not OfficerShootButton button || button.Target == null)
+        {
+            return;
+        }
+
+        if (PlayerControl.LocalPlayer.Data?.Role is not OfficerRole)
         {
             return;
         }

--- a/TownOfUs/Options/Roles/Crewmate/OfficerOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/OfficerOptions.cs
@@ -16,7 +16,7 @@ public sealed class OfficerOptions : AbstractRoleOptionGroup<OfficerRole>, IWiki
     public ModdedNumberOption LoadCooldown { get; set; } = new("TouOptionOfficerLoadCooldown", 25f, 2.5f, 120f, 2.5f,
         MiraNumberSuffixes.Seconds);
 
-    public ModdedNumberOption LoadDelay { get; set; } = new("TouOptionOfficerLoadDelay", 5f, 0f, 5f, 0.5f,
+    public ModdedNumberOption LoadDelay { get; set; } = new("TouOptionOfficerLoadDelay", 2.5f, 0f, 5f, 0.5f,
         MiraNumberSuffixes.Seconds);
 
     public ModdedToggleOption CanSelfReport { get; set; } = new("TouOptionOfficerCanSelfReport", false);

--- a/TownOfUs/Options/Roles/Crewmate/OfficerOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/OfficerOptions.cs
@@ -23,6 +23,9 @@ public sealed class OfficerOptions : AbstractRoleOptionGroup<OfficerRole>, IWiki
 
     public ModdedToggleOption FirstRoundShooting { get; set; } = new("TouOptionOfficerFirstRound", false);
 
+    public ModdedToggleOption BlockedShotConsumesBullet { get; set; } =
+        new("TouOptionOfficerBlockedShotConsumesBullet", true);
+
     public ModdedToggleOption CanOnlyShootActiveKillers { get; set; } =
         new("TouOptionOfficerCanOnlyShootActiveKillers", true);
 

--- a/TownOfUs/Options/Roles/Crewmate/OfficerOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/OfficerOptions.cs
@@ -13,7 +13,10 @@ public sealed class OfficerOptions : AbstractRoleOptionGroup<OfficerRole>, IWiki
     public ModdedNumberOption ShootCooldown { get; set; } = new("TouOptionOfficerShootCooldown", 5f, 2.5f, 30f, 2.5f,
         MiraNumberSuffixes.Seconds);
 
-    public ModdedNumberOption LoadCooldown { get; set; } = new("TouOptionOfficerLoadCooldown", 30f, 2.5f, 120f, 2.5f,
+    public ModdedNumberOption LoadCooldown { get; set; } = new("TouOptionOfficerLoadCooldown", 25f, 2.5f, 120f, 2.5f,
+        MiraNumberSuffixes.Seconds);
+
+    public ModdedNumberOption LoadDelay { get; set; } = new("TouOptionOfficerLoadDelay", 5f, 0f, 5f, 0.5f,
         MiraNumberSuffixes.Seconds);
 
     public ModdedToggleOption CanSelfReport { get; set; } = new("TouOptionOfficerCanSelfReport", false);

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1363,6 +1363,7 @@
   <!-- Officer Options -->
   <string name="TouOptionOfficerShootCooldown">Shoot Cooldown</string>
   <string name="TouOptionOfficerLoadCooldown">Load Cooldown</string>
+  <string name="TouOptionOfficerLoadDelay">Load Delay</string>
   <string name="TouOptionOfficerCanSelfReport">Can Self Report</string>
   <string name="TouOptionOfficerCanOnlyShootActiveKillers">Officer Can Only Shoot Players That Have Killed</string>
   <string name="TouOptionOfficerCrewKillingAreInnocent">Crewmate Killing Roles are Innocent</string>

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1365,6 +1365,7 @@
   <string name="TouOptionOfficerLoadCooldown">Load Cooldown</string>
   <string name="TouOptionOfficerLoadDelay">Load Delay</string>
   <string name="TouOptionOfficerCanSelfReport">Can Self Report</string>
+  <string name="TouOptionOfficerBlockedShotConsumesBullet">Blocked Shot Consumes Bullet</string>
   <string name="TouOptionOfficerCanOnlyShootActiveKillers">Officer Can Only Shoot Players That Have Killed</string>
   <string name="TouOptionOfficerCrewKillingAreInnocent">Crewmate Killing Roles are Innocent</string>
   <string name="TouOptionOfficerNonKillingNeutralsAreInnocent">Non-Killing Neutrals are Innocent</string>


### PR DESCRIPTION
## Additions
 -**Load Delay** option (0-5s) (default: 5s)
Pressing load now stars a countdown before it gets loaded. Calling a meeting mid load cancels the load without spending the bullet.

- **Blocked Shot Consumes Bullet** (default: True)
When set on true, when the officer shot is blocked by any protection the loaded bullet is spent. 

## Other Changes
- Default Load Cooldown reduced from 30s --> 25s

## Implementation Notes
-`OfficerShootButton` follow the `EngineerFixbutton`/`EngineerVentButton`
pattern: `ClickHandler` skips the early use-spend, and `OnEffectEnd` applies to the load only if no meeting interrupted and the round hasn't changed.
-No changes to `OfficerShootButtton` the blocked shot logic lives in the event handler.

## Testing
Testing all the options, everything worked as intended.

Made with help of Claude 4.8 and Fable 5.