### PR TITLE
Option to hide impostor count  + Jester flair

### DIFF
--- a/TownOfUs/Options/VanillaTweakOptions.cs
+++ b/TownOfUs/Options/VanillaTweakOptions.cs
@@ -20,6 +20,12 @@ public sealed class VanillaTweakOptions : AbstractOptionGroup
     public ModdedEnumOption SkipButtonDisable { get; set; } = new("Disable Meeting Skip Button", (int)SkipState.No,
         typeof(SkipState), ["Never", "Emergency", "Always"]);
 
+    public ModdedToggleOption HideRemainingImpostorCount { get; set; } = new("Hide Remaining Impostor Count", false)
+    {
+        Visible = () => GameManager.Instance != null && GameManager.Instance.LogicOptions != null &&
+                        GameManager.Instance.LogicOptions.GetConfirmImpostor()
+    };
+
     public ModdedToggleOption HideVentAnimationNotInVision { get; set; } =
         new("Hide Vent Animations Not In Vision", true);
 

--- a/TownOfUs/Patches/Options/ExileImpostorCountPatch.cs
+++ b/TownOfUs/Patches/Options/ExileImpostorCountPatch.cs
@@ -1,0 +1,32 @@
+using HarmonyLib;
+using MiraAPI.GameOptions;
+using TownOfUs.Options;
+
+namespace TownOfUs.Patches.Options;
+
+[HarmonyPatch]
+public static class ExileImpostorCountPatch
+{
+    [HarmonyPatch(typeof(ExileController), nameof(ExileController.HandleText))]
+    [HarmonyPatch(typeof(AirshipExileController), nameof(AirshipExileController.HandleText))]
+    [HarmonyPostfix]
+    public static void HideImpostorCountPostfix(ExileController __instance)
+    {
+        if (!OptionGroupSingleton<VanillaTweakOptions>.Instance.HideRemainingImpostorCount.Value)
+        {
+            return;
+        }
+
+        if (GameManager.Instance == null || GameManager.Instance.LogicOptions == null ||
+            !GameManager.Instance.LogicOptions.GetConfirmImpostor())
+        {
+            return;
+        }
+
+        if (__instance.ImpostorText != null)
+        {
+            __instance.ImpostorText.text = string.Empty;
+            __instance.ImpostorText.gameObject.SetActive(false);
+        }
+    }
+}

--- a/TownOfUs/Patches/Roles/JesterExilePatch.cs
+++ b/TownOfUs/Patches/Roles/JesterExilePatch.cs
@@ -1,0 +1,44 @@
+using HarmonyLib;
+using TownOfUs.Modules;
+using TownOfUs.Roles.Neutral;
+
+namespace TownOfUs.Patches.Roles;
+
+[HarmonyPatch]
+public static class JesterExilePatch
+{
+    [HarmonyPatch(typeof(ExileController), nameof(ExileController.HandleText))]
+    [HarmonyPatch(typeof(AirshipExileController), nameof(AirshipExileController.HandleText))]
+    [HarmonyPostfix]
+    public static void JesterEmphasisPostfix(ExileController __instance)
+    {
+        var exiled = __instance.initData?.networkedPlayer?.Object;
+        if (exiled == null)
+        {
+            return;
+        }
+
+        if (GameManager.Instance == null || GameManager.Instance.LogicOptions == null ||
+            !GameManager.Instance.LogicOptions.GetConfirmImpostor())
+        {
+            return;
+        }
+
+        if (exiled.GetRoleWhenAlive() is not JesterRole)
+        {
+            return;
+        }
+
+        var text = __instance.completeString;
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        var lastDot = text.LastIndexOf('.');
+        if (lastDot >= 0)
+        {
+            __instance.completeString = text[..lastDot] + "!" + text[(lastDot + 1)..];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
-Adds **Hide Remaining Impostor Count** toggle (Vanilla tweaks, default: False)
removes the "X Impostors remain" line from the ejection screen, for lobby with confirm eject set on **True** for lobbies where confirming roles is fine but tracking the impostor count is too much info.
-Small little tweak: with confirm ejects on, when **Jester** is ejected it now says "X was the Jester!" an exclamation mark instead of a period.

The toggle only appears and acts when confirm is set on True and does nothing otherwise.

With help from Claude
