### PR TITLE
Fixed inquisitor 1v1 win check

### DIFF
--- a/TownOfUs/Roles/Classic/Neutral/NeutralOutlier/InquisitorRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralOutlier/InquisitorRole.cs
@@ -239,12 +239,20 @@ public sealed class InquisitorRole(IntPtr cppPtr) : NeutralRole(cppPtr), ITownOf
             return false;
         }
 
-        if (!OptionGroupSingleton<InquisitorOptions>.Instance.StallGame)
+        // Needed for the 1v1. The end check can run mid-kill, before TargetsDead is set, so read live state instead - Divani :)
+        if (Helpers.GetAlivePlayers().Contains(Player) && Helpers.GetAlivePlayers().Count <= 1 &&
+            Targets.Count > 0)
+        {
+            return true;
+        }
+
+        if (!TargetsDead)
         {
             return false;
         }
 
-        if (!TargetsDead)
+        // Must stay below the solo win above; at the top of the method it blocked it.
+        if (!OptionGroupSingleton<InquisitorOptions>.Instance.StallGame)
         {
             return false;
         }


### PR DESCRIPTION
# Inquisitor never solo-wins in a 1v1

`WinConditionMet()` needs `KillersAliveCount == 1`, but the Inquisitor is `NeutralOutlier` and does
not count as a killer, so after killing the last heretic (the imp) the count is 0 and the check
fails. You get a crew win without the Inquisitor tagged along, no solo win.

Fix: check `TargetsDead` before the `StallGame` gate, and win when
`Helpers.GetAlivePlayers().Count <= 1`. 