### PR TITLE
Add Doomsayer option to guess factions instead of roles

### DIFF
--- a/TownOfUs/Modules/Components/GuesserMenu.cs
+++ b/TownOfUs/Modules/Components/GuesserMenu.cs
@@ -22,6 +22,7 @@ public sealed class GuesserMenu(IntPtr cppPtr) : Minigame(cppPtr)
     private UiElement? backButton;
     private int currentPage;
     private UiElement? defaultButtonSelected;
+    private Action<GuessCategory>? onCategoryClick;
     private Action<BaseModifier>? onModifierClick;
     private Action<RoleBehaviour>? onRoleClick;
     private ShapeshifterPanel? panelPrefab;
@@ -392,15 +393,36 @@ public sealed class GuesserMenu(IntPtr cppPtr) : Minigame(cppPtr)
 
     [HideFromIl2Cpp]
     public void Begin(Func<RoleBehaviour, bool> roleMatch, Action<RoleBehaviour> roleClickHandler,
-        Func<BaseModifier, bool>? modifierMatch = null, Action<BaseModifier>? modifierClickHandler = null)
+        Func<BaseModifier, bool>? modifierMatch = null, Action<BaseModifier>? modifierClickHandler = null,
+        List<GuessCategory>? categories = null, Action<GuessCategory>? categoryClickHandler = null)
     {
         MinigameStubs.Begin(this, null);
 
         onRoleClick = roleClickHandler;
         onModifierClick = modifierClickHandler;
+        onCategoryClick = categoryClickHandler;
         allEntries = [];
         searchText = string.Empty;
         currentPage = 0;
+
+        if (categories != null && onCategoryClick != null)
+        {
+            for (var i = 0; i < categories.Count; i++)
+            {
+                var category = categories[i];
+
+                var categoryPanel = Instantiate(panelPrefab, transform);
+                categoryPanel!.transform.localPosition = new Vector3(0f, 0f, -1f);
+                categoryPanel.SetCategory(i, category.Name, category.Color, category.Icon.LoadAsset(),
+                    () => { onCategoryClick(category); });
+                categoryPanel.gameObject.transform.FindChild("Nameplate").FindChild("Highlight")
+                    .FindChild("ShapeshifterIcon").gameObject.SetActive(false);
+
+                allEntries.Add(new MenuEntry(categoryPanel, category.Name));
+            }
+        }
+
+        var categoryCount = allEntries.Count;
 
         var roles = MiscUtils.GetPotentialRoles().Where(roleMatch).ToList();
 
@@ -428,7 +450,7 @@ public sealed class GuesserMenu(IntPtr cppPtr) : Minigame(cppPtr)
 
             var shapeshifterPanel = Instantiate(panelPrefab, transform);
             shapeshifterPanel!.transform.localPosition = new Vector3(0f, 0f, -1f);
-            shapeshifterPanel.SetRole(i, role, () => { onRoleClick(role); });
+            shapeshifterPanel.SetRole(categoryCount + i, role, () => { onRoleClick(role); });
             shapeshifterPanel.gameObject.transform.FindChild("Nameplate").FindChild("Highlight")
                 .FindChild("ShapeshifterIcon").gameObject.SetActive(false);
 
@@ -441,7 +463,7 @@ public sealed class GuesserMenu(IntPtr cppPtr) : Minigame(cppPtr)
 
             for (var i = 0; i < modifiers.Count; i++)
             {
-                var index = newRoleList.Count + i;
+                var index = categoryCount + newRoleList.Count + i;
                 var modifier = modifiers[i];
 
                 var shapeshifterPanel = Instantiate(panelPrefab, transform);
@@ -476,3 +498,9 @@ public sealed class GuesserMenu(IntPtr cppPtr) : Minigame(cppPtr)
         }
     }
 }
+
+public sealed record GuessCategory(
+    string Name,
+    Color Color,
+    LoadableAsset<Sprite> Icon,
+    Func<RoleBehaviour, bool> Matches);

--- a/TownOfUs/Options/Roles/Neutral/DoomsayerOptions.cs
+++ b/TownOfUs/Options/Roles/Neutral/DoomsayerOptions.cs
@@ -27,6 +27,11 @@ public sealed class DoomsayerOptions : AbstractRoleOptionGroup<DoomsayerRole>
         Visible = () => OptionGroupSingleton<DoomsayerOptions>.Instance.DoomsayerGuessAllAtOnce
     };
 
+    public ModdedToggleOption DoomsayerGuessByCategory { get; set; } = new("TouOptionDoomsayerGuessByCategory", false)
+    {
+        Visible = () => OptionGroupSingleton<DoomsayerOptions>.Instance.DoomsayerGuessAllAtOnce
+    };
+
     [ModdedToggleOption("TouOptionDoomsayerCantObserve")]
     public bool CantObserve { get; set; } = false;
 

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -2025,6 +2025,7 @@
   <string name="TouOptionDoomsayerGuessesAllAtOnce">Doomsayer Guesses All Roles At Once</string>
   <string name="TouOptionDoomsayerCantObserve">Doomsayer Can't Observe</string>
   <string name="TouOptionDoomsayerOnlyKillLast">Kill Only The Last Victim</string>
+  <string name="TouOptionDoomsayerGuessByCategory">Guess Factions Instead Of Roles</string>
   <string name="TouOptionDoomsayerWin">Doomsayer Win</string>
   <string name="TouOptionDoomsayerWinEnumEndsGame">Ends Game</string>
   <string name="TouOptionDoomsayerWinEnumLeaves">Leaves In Victory</string>
@@ -2033,6 +2034,8 @@
   <!-- Doomsayer Misguess -->
   <string name="TouRoleDoomsayerMisguessOne">Only one guess was incorrect!</string>
   <string name="TouRoleDoomsayerMisguessMultiple">\%misguessCount\% guesses were incorrect.</string>
+  <string name="TouRoleDoomsayerMisguessVague">At least one guess was incorrect.</string>
+  <string name="TouRoleDoomsayerCategoryImpostor">Random Impostor</string>
   <!-- Doomsayer Feedback -->
   <string name="TouRoleDoomsayerMessageTitle">Doomsayer Report</string>
   <string name="TouRoleDoomsayerRoleHintPerception">You observe that \%player\% has an altered perception of reality</string>

--- a/TownOfUs/Roles/Classic/Neutral/NeutralEvil/DoomsayerRole.cs
+++ b/TownOfUs/Roles/Classic/Neutral/NeutralEvil/DoomsayerRole.cs
@@ -388,7 +388,39 @@ public sealed class DoomsayerRole(IntPtr cppPtr)
         var player = GameData.Instance.GetPlayerById(voteArea.TargetPlayerId).Object;
 
         var shapeMenu = GuesserMenu.Create();
-        shapeMenu.Begin(IsRoleValid, ClickRoleHandle);
+
+        if (OptionGroupSingleton<DoomsayerOptions>.Instance.DoomsayerGuessAllAtOnce &&
+            OptionGroupSingleton<DoomsayerOptions>.Instance.DoomsayerGuessByCategory)
+        {
+            shapeMenu.Begin(x => IsRoleValid(x) && x.IsCrewmate(), ClickRoleHandle, null, null, BuildCategories(),
+                ClickCategoryHandle);
+        }
+        else
+        {
+            shapeMenu.Begin(IsRoleValid, ClickRoleHandle);
+        }
+
+        void ClickCategoryHandle(GuessCategory category)
+        {
+            var realRole = player.Data.Role;
+
+            var pickVictim = category.Matches(realRole);
+            if (player.GetModifiers<BaseModifier>().FirstOrDefault(x => x is ICachedRole) is ICachedRole cachedMod)
+            {
+                pickVictim = cachedMod.GuessMode switch
+                {
+                    // Checks for the role the player is at the moment
+                    CacheRoleGuess.ActiveRole => category.Matches(realRole),
+                    // Checks for the cached role itself (like Imitator or Traitor)
+                    CacheRoleGuess.CachedRole => category.Matches(cachedMod.CachedRole),
+                    // Checks if it's the cached or active role
+                    _ => category.Matches(cachedMod.CachedRole) || category.Matches(realRole),
+                };
+            }
+            var victim = pickVictim ? player : Player;
+
+            ClickHandler(victim, voteArea.TargetPlayerId);
+        }
 
         void ClickRoleHandle(RoleBehaviour role)
         {
@@ -458,9 +490,11 @@ public sealed class DoomsayerRole(IntPtr cppPtr)
 
             if (IncorrectGuesses > 0 && opts.DoomsayerGuessAllAtOnce)
             {
-                var text = NumberOfGuesses - AllVictims.Count == 1
-                    ? $"<b>{TouLocale.GetParsed("TouRoleDoomsayerMisguessOne")}</b>"
-                    : $"<b>{TouLocale.GetParsed("TouRoleDoomsayerMisguessMultiple").Replace("<misguessCount>", $"{NumberOfGuesses - AllVictims.Count}")}</b>";
+                var text = opts.DoomsayerGuessByCategory
+                    ? $"<b>{TouLocale.GetParsed("TouRoleDoomsayerMisguessVague")}</b>"
+                    : NumberOfGuesses - AllVictims.Count == 1
+                        ? $"<b>{TouLocale.GetParsed("TouRoleDoomsayerMisguessOne")}</b>"
+                        : $"<b>{TouLocale.GetParsed("TouRoleDoomsayerMisguessMultiple").Replace("<misguessCount>", $"{NumberOfGuesses - AllVictims.Count}")}</b>";
                 var notif1 = Helpers.CreateAndShowNotification(
                     text, Color.white, new Vector3(0f, 1f, -20f), spr: TouRoleIcons.Doomsayer.LoadAsset());
 
@@ -532,6 +566,32 @@ public sealed class DoomsayerRole(IntPtr cppPtr)
                voteArea.GetPlayer()?.HasModifier<JailedModifier>() == true ||
                (voteArea.GetPlayer()?.Data.Role is MayorRole mayor && mayor.Revealed) ||
                (Player.IsLover() && voteArea.GetPlayer()?.IsLover() == true);
+    }
+
+    private static List<GuessCategory> BuildCategories()
+    {
+        var categories = new List<GuessCategory>();
+        var potentialRoles = MiscUtils.GetPotentialRoles().Where(IsRoleValid).ToList();
+
+        if (potentialRoles.Any(x => x.IsImpostor()))
+        {
+            categories.Add(new GuessCategory(
+                TouLocale.Get("TouRoleDoomsayerCategoryImpostor", "Random Impostor"),
+                TownOfUsColors.Impostor,
+                TouRoleIcons.RandomImp,
+                x => x.IsImpostor() && IsRoleValid(x)));
+        }
+
+        foreach (var alignment in potentialRoles.Where(x => x.IsNeutral()).Select(x => x.GetRoleAlignment()).Distinct())
+        {
+            categories.Add(new GuessCategory(
+                MiscUtils.GetParsedRoleAlignment(alignment),
+                TownOfUsColors.Neutral,
+                TouRoleIcons.RandomNeut,
+                x => x.GetRoleAlignment() == alignment && IsRoleValid(x)));
+        }
+
+        return categories;
     }
 
     private static bool IsRoleValid(RoleBehaviour role)

--- a/TownOfUs/Utilities/Extensions.cs
+++ b/TownOfUs/Utilities/Extensions.cs
@@ -285,6 +285,54 @@ public static class Extensions
         }
     }
 
+    public static void SetCategory(this ShapeshifterPanel panel, int index, string name, Color color, Sprite icon,
+        Action onClick)
+    {
+        panel.shapeshift = onClick;
+        panel.PlayerIcon.SetFlipX(false);
+        panel.PlayerIcon.ToggleName(false);
+        panel.PlayerIcon.gameObject.SetActive(false);
+
+        SpriteRenderer[] componentsInChildren = panel.GetComponentsInChildren<SpriteRenderer>();
+
+        foreach (var spriteRend in componentsInChildren)
+        {
+            spriteRend.material.SetInt(PlayerMaterial.MaskLayer, index + 2);
+        }
+
+        panel.PlayerIcon.SetMaskLayer(index + 2);
+        panel.PlayerIcon.cosmetics.SetMaskType(PlayerMaterial.MaskType.ComplexUI);
+
+        foreach (var hand in panel.PlayerIcon.Hands)
+        {
+            hand.sharedMaterial = CosmeticsLayer.GetBodyMaterial(PlayerMaterial.MaskType.ComplexUI);
+            hand.gameObject.active = false;
+        }
+
+        foreach (var sprite in panel.PlayerIcon.OtherBodySprites)
+        {
+            sprite.sharedMaterial = CosmeticsLayer.GetBodyMaterial(PlayerMaterial.MaskType.ComplexUI);
+            sprite.gameObject.active = false;
+        }
+
+        var roleIcon = Object.Instantiate(panel.Background, panel.transform).gameObject;
+        roleIcon.name = "RoleIcon";
+        roleIcon.GetComponent<PassiveButton>().Destroy();
+        roleIcon.gameObject.transform.localScale = new Vector3(0.21f, 0.9f, 1);
+        roleIcon.gameObject.transform.localPosition += new Vector3(-0.964f, 0, -2);
+
+        roleIcon.gameObject.GetComponent<SpriteRenderer>().sprite = icon;
+        roleIcon.gameObject.SetActive(true);
+
+        var finalString = $"<size=88%>{name}</size>";
+
+        panel.LevelNumberText.transform.parent.gameObject.SetActive(false);
+        panel.NameText.color = color;
+        panel.NameText.text = finalString;
+        panel.NameText.alignment = TextAlignmentOptions.Right;
+        panel.NameText.transform.localPosition += Vector3.left * 0.05f;
+    }
+
     public static void SetRole(this ShapeshifterPanel panel, int index, RoleBehaviour roleBehaviour, Action onClick)
     {
         panel.shapeshift = onClick;


### PR DESCRIPTION
Adds a new setting under **Doomsayer Guesses All Roles At Once** that changes the guessing

-All Impostor roles become a single **Random Impostor**
-Neutral roles become sub-alingment (Neutral Benign, Neutral Evil...)
-Crewmate roles are NOT changed

I also made misguess feedback more vaguer with the new option turned on it now says: "At least one guess was incorrect" instead of naming the exact number of wrong guesses.

### Why
Guessing all roles at once in a single meeting is a **WAY** different task than guessing one by one and from personal experience makes the role almost impossible to win especially with 3 guesses at once, this by no means makes the role free and overpowered since it's **heavily** on the Doomsayers deduction on figuring out whos evil and what kind of evil, instead of praying some evil role leaks their role. There are many games were there are no obvious role clues to deduct and can make the process RNG which this resolves but still doesn't make it easy by any means. Hiding the misguess counter was one of the ideas behind making it having to be a proper read by the doomsayer instead of trial and error.

### Notes
- **Off by default** same version as current doom
- Roles marked with `IUnguessable` won't count as a valid guess

### Testing
Tested like 20 games correct and inccorect guesses, and the doomsayer guessing doesn't also somehow bleed into an assasin's guessing menu also verified that.