### PR TITLE
Seer balancing settings

### DIFF
--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SeerGazeButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SeerGazeButton.cs
@@ -21,6 +21,13 @@ public sealed class SeerGazeButton : TownOfUsRoleButton<SeerRole, PlayerControl>
         return base.Enabled(role) &&
                OptionGroupSingleton<SeerOptions>.Instance.SalemSeer;
     }
+
+    public override bool CanUse()
+    {
+        return base.CanUse() &&
+               (OptionGroupSingleton<SeerOptions>.Instance.CanUseMultiplePerRound || !Role.UsedThisRound);
+    }
+
     public override float Cooldown => Math.Clamp(OptionGroupSingleton<SeerOptions>.Instance.SeerCooldown + MapCooldown, 5f, 120f);
     public override LoadableAsset<Sprite> Sprite => TouCrewAssets.GazeSprite;
 
@@ -32,7 +39,7 @@ public sealed class SeerGazeButton : TownOfUsRoleButton<SeerRole, PlayerControl>
     public override PlayerControl? GetTarget()
     {
         return PlayerControl.LocalPlayer.GetClosestLivingPlayer(true, Distance,
-            predicate: x => Role.GazeTarget != x && Role.IntuitTarget != x && !x.HasModifier<BaseRevealModifier>(y => y.RevealRole && y.Visible));
+            predicate: x => Role.GazeTarget != x && Role.IntuitTarget != x && Role.CanCompare(x) && !x.HasModifier<BaseRevealModifier>(y => y.RevealRole && y.Visible));
     }
 
     protected override void OnClick()

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SeerIntuitButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SeerIntuitButton.cs
@@ -21,6 +21,13 @@ public sealed class SeerIntuitButton : TownOfUsRoleButton<SeerRole, PlayerContro
         return base.Enabled(role) &&
                OptionGroupSingleton<SeerOptions>.Instance.SalemSeer;
     }
+
+    public override bool CanUse()
+    {
+        return base.CanUse() &&
+               (OptionGroupSingleton<SeerOptions>.Instance.CanUseMultiplePerRound || !Role.UsedThisRound);
+    }
+
     public override float Cooldown => Math.Clamp(OptionGroupSingleton<SeerOptions>.Instance.SeerCooldown + MapCooldown, 5f, 120f);
     public override LoadableAsset<Sprite> Sprite => TouCrewAssets.IntuitSprite;
 
@@ -32,7 +39,7 @@ public sealed class SeerIntuitButton : TownOfUsRoleButton<SeerRole, PlayerContro
     public override PlayerControl? GetTarget()
     {
         return PlayerControl.LocalPlayer.GetClosestLivingPlayer(true, Distance,
-            predicate: x => Role.GazeTarget != x && Role.IntuitTarget != x && !x.HasModifier<BaseRevealModifier>(y => y.RevealRole && y.Visible));
+            predicate: x => Role.GazeTarget != x && Role.IntuitTarget != x && Role.CanCompare(x) && !x.HasModifier<BaseRevealModifier>(y => y.RevealRole && y.Visible));
     }
 
     protected override void OnClick()

--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SeerRevealButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmateInvestigative/SeerRevealButton.cs
@@ -24,6 +24,12 @@ public sealed class SeerRevealButton : TownOfUsRoleButton<SeerRole, PlayerContro
                !OptionGroupSingleton<SeerOptions>.Instance.SalemSeer;
     }
 
+    public override bool CanUse()
+    {
+        return base.CanUse() &&
+               (OptionGroupSingleton<SeerOptions>.Instance.CanUseMultiplePerRound || !Role.UsedThisRound);
+    }
+
     public override bool IsTargetValid(PlayerControl? target)
     {
         return base.IsTargetValid(target) && !target!.HasModifier<SeerGoodRevealModifier>() &&
@@ -43,6 +49,7 @@ public sealed class SeerRevealButton : TownOfUsRoleButton<SeerRole, PlayerContro
         }
 
         RevealAlliance(Target);
+        Role.UsedThisRound = true;
         TouAudio.PlaySound(TouAudio.QuestionSound);
 
         Target?.cosmetics.SetOutline(false, new Il2CppSystem.Nullable<Color>(TownOfUsColors.Seer));

--- a/TownOfUs/Events/Crewmate/SeerEvents.cs
+++ b/TownOfUs/Events/Crewmate/SeerEvents.cs
@@ -1,0 +1,18 @@
+using MiraAPI.Events;
+using MiraAPI.Events.Vanilla.Gameplay;
+using MiraAPI.Roles;
+using TownOfUs.Roles.Crewmate;
+
+namespace TownOfUs.Events.Crewmate;
+
+public static class SeerEvents
+{
+    [RegisterEvent]
+    public static void RoundStartEventHandler(RoundStartEvent _)
+    {
+        foreach (var seer in CustomRoleUtils.GetActiveRolesOfType<SeerRole>())
+        {
+            seer.UsedThisRound = false;
+        }
+    }
+}

--- a/TownOfUs/Options/Roles/Crewmate/SeerOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/SeerOptions.cs
@@ -18,6 +18,13 @@ public sealed class SeerOptions : AbstractRoleOptionGroup<SeerRole>
     [ModdedNumberOption("TouOptionSeerUses", 0f, 15f, 1f, MiraNumberSuffixes.None, "0", true)]
     public float MaxCompares { get; set; } = 5f;
 
+    public ModdedToggleOption CanUseMultiplePerRound { get; set; } = new("TouOptionSeerMultiplePerRound", false);
+
+    public ModdedToggleOption CompareEachPlayerOnce { get; set; } = new("TouOptionSeerCompareEachPlayerOnce", false)
+    {
+        Visible = () => OptionGroupSingleton<SeerOptions>.Instance.SalemSeer
+    };
+
     public ModdedToggleOption BenignShowFriendlyToAll { get; set; } = new("TouOptionSeerNeutralBenignFriendly", false)
     {
         Visible = () => OptionGroupSingleton<SeerOptions>.Instance.SalemSeer

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1233,6 +1233,8 @@
   <string name="TouOptionSeerSalemMode">Compare Players Instead of Checking Alignments</string>
   <string name="TouOptionSeerCooldown">Reveal/Compare Cooldown</string>
   <string name="TouOptionSeerUses">Max Uses of Reveal/Compare</string>
+  <string name="TouOptionSeerMultiplePerRound">Can Reveal/Compare More Than Once Per Round</string>
+  <string name="TouOptionSeerCompareEachPlayerOnce">Can Only Compare Each Player Once</string>
   <string name="TouOptionSeerNeutralBenignFriendly">Neutral Benign Show Friends To All</string>
   <string name="TouOptionSeerNeutralEvilFriendly">Neutral Evils Show Friends To All</string>
   <string name="TouOptionSeerNeutralOutlierFriendly">Neutral Outliers Show Friends To All</string>

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SeerRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SeerRole.cs
@@ -67,6 +67,8 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
     };
     [HideFromIl2Cpp] public PlayerControl? GazeTarget { get; set; }
     [HideFromIl2Cpp] public PlayerControl? IntuitTarget { get; set; }
+    [HideFromIl2Cpp] public List<PlayerControl> ComparedPlayers { get; } = [];
+    public bool UsedThisRound { get; set; }
 
     public static string TabHeaderString = TouLocale.GetParsed("TouRoleSeerTabHeader");
     public override void Initialize(PlayerControl player)
@@ -75,7 +77,14 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
         IntuitTarget = null;
         RoleBehaviourStubs.Initialize(this, player);
         ComparisonList = [];
+        ComparedPlayers.Clear();
         TabHeaderString = TouLocale.GetParsed("TouRoleSeerTabHeader");
+    }
+
+    [HideFromIl2Cpp]
+    public bool CanCompare(PlayerControl player)
+    {
+        return !OptionGroupSingleton<SeerOptions>.Instance.CompareEachPlayerOnce || !ComparedPlayers.Contains(player);
     }
 
     public override void OnMeetingStart()
@@ -179,8 +188,20 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
             var compareResult = TouLocale.GetParsed("TouRoleSeerTabComparison").Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
             ComparisonList.Add($"<b>{Palette.CrewmateBlue.ToTextColor()}{compareResult.Replace("<num>", DeathEventHandlers.CurrentRound.ToString(TownOfUsPlugin.Culture))}</color></b>");
         }
+
+        if (GazeTarget != null)
+        {
+            ComparedPlayers.Add(GazeTarget);
+        }
+
+        if (IntuitTarget != null)
+        {
+            ComparedPlayers.Add(IntuitTarget);
+        }
+
         IntuitTarget = null;
         GazeTarget = null;
+        UsedThisRound = true;
     }
 
     [HideFromIl2Cpp]


### PR DESCRIPTION
Adds 2 new settings for seer

### Can Reveal/Compare More than once per round
(Default true) on true the seer can only compare/reveal once per round, applys to both seer modes, reveal and compare

### Can Only Compare Each Player Once
(Default false) only available to compare mode, it makes it so on True you can only compare each person once per game, so both players who get compared are permanently unable to be compared to anyone.

Without this a seer can re-compare good crew against new suspects and cross check compares to find evils. Host can opt this on for a more strict and balanced seer. Blocked players dont make the buttons light up.
