### PR TITLE
Add Lookout option to only see evil interactions

### DIFF
--- a/TownOfUs/Options/Roles/Crewmate/LookoutOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/LookoutOptions.cs
@@ -20,6 +20,11 @@ public sealed class LookoutOptions : AbstractRoleOptionGroup<LookoutRole>
 
     public ModdedToggleOption LookoutSeesIndirectAttacks { get; } = new("TouOptionLookoutSeesIndirectAttacks", false);
 
+    public ModdedToggleOption OnlySeesEvilInteractions { get; } = new("TouOptionLookoutOnlySeesEvilInteractions", true)
+    {
+        Visible = () => (LookoutView)OptionGroupSingleton<LookoutOptions>.Instance.WatchType.Value is LookoutView.Roles
+    };
+
     [ModdedToggleOption("TouOptionLookoutLoResetOnNewRound")]
     public bool LoResetOnNewRound { get; set; } = true;
 

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -983,6 +983,7 @@
   <string name="TouOptionLookoutWatchCooldown">Watch Cooldown</string>
   <string name="TouOptionLookoutMaxWatches">Initial Players That Can be Watched</string>
   <string name="TouOptionLookoutSeesIndirectAttacks">See Indirect Attacks</string>
+  <string name="TouOptionLookoutOnlySeesEvilInteractions">Only See Evil Interactions</string>
   <string name="TouOptionLookoutLoResetOnNewRound">Lookout Watches Reset After Each Round</string>
   <string name="TouOptionLookoutTaskUses">Get More Uses From Completing Tasks</string>
   <!-- Mayor - Crewmate Power -->

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/LookoutRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/LookoutRole.cs
@@ -4,6 +4,7 @@ using MiraAPI.Modifiers;
 using MiraAPI.Roles;
 using Reactor.Networking.Attributes;
 using TownOfUs.Modifiers.Crewmate;
+using TownOfUs.Modifiers.Game.Alliance;
 using TownOfUs.Modules;
 using TownOfUs.Options.Roles.Crewmate;
 using UnityEngine;
@@ -75,6 +76,14 @@ public sealed class LookoutRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
         if (source.GetModifiers<BaseModifier>().FirstOrDefault(x => x is ICachedRole) is ICachedRole cachedMod)
         {
             role = cachedMod.CachedRole;
+        }
+
+        var opt = OptionGroupSingleton<LookoutOptions>.Instance;
+        if (opt.OnlySeesEvilInteractions && (LookoutView)opt.WatchType.Value is LookoutView.Roles &&
+            role.IsCrewmate() && !source.HasModifier<CrewpostorModifier>() &&
+            !source.HasModifier<EgotistModifier>() && !source.HasModifier<LoverModifier>(x => !x.DoesTasks))
+        {
+            return;
         }
 
         // Prevents duplicate role entries


### PR DESCRIPTION
### New
Adds a new option for lookout under `Watched Player Feedback Reveal` set to **Roles** Called: **Only See Evil Interactions**

It makes it so that you only get feedback if an evil interacted with the person you watched 
evil being: Neutrals, Impostors, Crewposter crewmate, Egoist crewmate, Lover with a evil lover

### Why?
This setting mostly is useful for lobbys with Unguessable investigative crewmates, it makes lookout easier to fake claim for evils since now they don't have to be aware of crewmate interactions they can't predict and called out for it
and it makes it harder for lookout to confirm crewmates or 2 lookouts confirm each other

Tested properly works every time