### PR TITLE
Add Unstoppable Ignite option for Arsonist

### DIFF
--- a/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/ArsonistIgniteButton.cs
+++ b/TownOfUs/Buttons/Classic/Neutral/NeutralKilling/ArsonistIgniteButton.cs
@@ -69,6 +69,7 @@ public sealed class ArsonistIgniteButton : TownOfUsRoleButton<ArsonistRole>, ILe
         if (dousedPlayers.Count > 0)
         {
             PlayerControl.LocalPlayer.RpcSpecialMultiMurder(dousedPlayers, MeetingCheck.OutsideMeeting, true,
+                ignoreShields: OptionGroupSingleton<ArsonistOptions>.Instance.UnstoppableIgnite,
                 teleportMurderer: false,
                 playKillSound: false,
                 causeOfDeath: "Arsonist");

--- a/TownOfUs/Options/Roles/Neutral/ArsonistOptions.cs
+++ b/TownOfUs/Options/Roles/Neutral/ArsonistOptions.cs
@@ -26,6 +26,9 @@ public sealed class ArsonistOptions : AbstractRoleOptionGroup<ArsonistRole>
         Visible = () => !OptionGroupSingleton<ArsonistOptions>.Instance.LegacyArsonist
     };
 
+    [ModdedToggleOption("TouOptionArsonistUnstoppableIgnite")]
+    public bool UnstoppableIgnite { get; set; }
+
     [ModdedToggleOption("TouOptionArsonistCanVent")]
     public bool CanVent { get; set; }
 

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1924,6 +1924,7 @@
   <string name="TouOptionArsonistDouseInteractions">Douse From Interactions</string>
   <string name="TouOptionArsonistLegacyMode">Legacy Mode (No Radius)</string>
   <string name="TouOptionArsonistIgniteRadius">Ignite Radius</string>
+  <string name="TouOptionArsonistUnstoppableIgnite">Unstoppable Ignite</string>
   <string name="TouOptionArsonistCanVent">Arsonist Can Vent</string>
   <string name="TouOptionArsonistImpVision">Has Impostor Vision</string>
   <!-- Doomsayer -->


### PR DESCRIPTION
### New
Adds a new **Unstoppable Ignite** option
If set on True it lets the Arsonist bypass all shields
Especially useful if Arsonist is set on Legacy Mode **False** because of the close proximity you have