### PR TITLE
Add option to reveal knighting at the next meeting

### DIFF
--- a/TownOfUs/Events/Misc/KnightedEvents.cs
+++ b/TownOfUs/Events/Misc/KnightedEvents.cs
@@ -1,8 +1,12 @@
 using MiraAPI.Events;
+using MiraAPI.Events.Vanilla.Meeting;
 using MiraAPI.Events.Vanilla.Meeting.Voting;
 using MiraAPI.GameOptions;
 using MiraAPI.Modifiers;
+using MiraAPI.Modifiers.ModifierDisplay;
+using MiraAPI.Utilities;
 using MiraAPI.Voting;
+using Reactor.Utilities.Extensions;
 using TownOfUs.Modifiers;
 using TownOfUs.Options.Roles.Crewmate;
 
@@ -13,6 +17,35 @@ public static class KnightedEvents
     public static List<CustomVote> ExtraKnightVotes { get; } = [];
     public static bool ShowVotes => OptionGroupSingleton<MonarchOptions>.Instance.ShowKnightedVotes;
     public static int TotalVotes => (int)OptionGroupSingleton<MonarchOptions>.Instance.VotesPerKnight + 1;
+
+    [RegisterEvent]
+    public static void StartMeetingEventHandler(StartMeetingEvent _)
+    {
+        if (!OptionGroupSingleton<MonarchOptions>.Instance.RevealAtMeeting || !HudManager.InstanceExists)
+        {
+            return;
+        }
+
+        var knights = PlayerControl.LocalPlayer.GetModifiers<KnightedModifier>().Where(x => !x.Announced).ToList();
+        if (knights.Count == 0)
+        {
+            return;
+        }
+
+        var title = $"<color=#{TownOfUsColors.Monarch.ToHtmlStringRGBA()}>{TouLocale.Get("TouRoleMonarchMessageTitle")}</color>";
+        var role = $"{TownOfUsColors.Monarch.ToTextColor()}{TouLocale.Get("TouRoleMonarch", "Monarch")}</color>";
+        var votes = ((int)OptionGroupSingleton<MonarchOptions>.Instance.VotesPerKnight).ToString(TownOfUsPlugin.Culture);
+
+        foreach (var knight in knights)
+        {
+            knight.Announced = true;
+
+            var message = TouLocale.GetParsed("TouRoleMonarchKnightedFeedback").Replace("<role>", role).Replace("<votes>", votes);
+            MiscUtils.AddFakeChat(PlayerControl.LocalPlayer.Data, title, message, false, true);
+        }
+
+        ModifierDisplayComponent.Instance?.RefreshModifiers();
+    }
 
     [RegisterEvent]
     public static void ProcessVotesEventHandler(ProcessVotesEvent @event)

--- a/TownOfUs/Modifiers/KnightedModifier.cs
+++ b/TownOfUs/Modifiers/KnightedModifier.cs
@@ -8,9 +8,11 @@ namespace TownOfUs.Modifiers;
 public sealed class KnightedModifier : BaseModifier
 {
     public override string ModifierName => "Knighted";
-    public override bool HideOnUi => false;
+    public override bool HideOnUi => OptionGroupSingleton<MonarchOptions>.Instance.RevealAtMeeting && !Announced;
     public override LoadableAsset<Sprite>? ModifierIcon => TouRoleIcons.Monarch;
     public override bool Unique => false;
+
+    public bool Announced { get; set; }
 
     public override string GetDescription()
     {

--- a/TownOfUs/Options/Roles/Crewmate/MonarchOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/MonarchOptions.cs
@@ -20,6 +20,9 @@ public sealed class MonarchOptions : AbstractRoleOptionGroup<MonarchRole>
     [ModdedNumberOption("Knight Delay (Cancellable)", 1f, 10f, 1f, MiraNumberSuffixes.Seconds)]
     public float KnightDelay { get; set; } = 3f;
 
+    [ModdedToggleOption("Reveal Knighting At Meeting")]
+    public bool RevealAtMeeting { get; set; } = false;
+
     [ModdedToggleOption("Show Knighted Votes")]
     public bool ShowKnightedVotes { get; set; } = true;
 

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1105,6 +1105,7 @@
   <string name="TouRoleMonarchKnightTargetDied">\%player\% died before you could knight them.</string>
   <string name="TouRoleMonarchKnightSuccess">\%player\% was knighted!</string>
   <string name="TouRoleMonarchKnightedFeedback">You were knighted by a \%role\%. You gained \%votes\% vote(s)!</string>
+  <string name="TouRoleMonarchMessageTitle">Monarch Feedback</string>
   <string name="TouRoleMonarchKnightFallenFeedback">Your knight, \%player\%, has fallen...</string>
   <!-- Mystic - Crewmate Investigative -->
   <!-- Mystic Wiki / Description -->

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmatePower/MonarchRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmatePower/MonarchRole.cs
@@ -129,7 +129,7 @@ public sealed class MonarchRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUs
             ShowNotification(TouLocale.GetParsed("TouRoleMonarchKnightSuccess").Replace("<player>", targetName));
         }
 
-        if (target.AmOwner)
+        if (target.AmOwner && !OptionGroupSingleton<MonarchOptions>.Instance.RevealAtMeeting)
         {
             ShowNotification(TouLocale.GetParsed("TouRoleMonarchKnightedFeedback").Replace("<role>", $"{TownOfUsColors.Monarch.ToTextColor()}{monarch.RoleName}</color>").Replace("<votes>", ((int)OptionGroupSingleton<MonarchOptions>.Instance.VotesPerKnight).ToString(TownOfUsPlugin.Culture)));
         }


### PR DESCRIPTION
### New
Adds **Reveal Knighting At Meeting** option for Monarch (Default False)

With it on False, it's how Monarch functions currently which is that after a delay the person monarch knights gets knighted and they're notified about it immediately

On True, the knight is given like usual on the Monarch's screen but the target is not notified about being knighted nor they will see the knight modifier on them UNTIL a meeting gets called then they will get a Monarch Feedback message notifying them they got knighted and it will appear in the modifier menu

This setting makes Monarch less likely to be cleared by crew or guessed by Assassin if they knighted a evil making their identity more hidden.

Tested both on True and False everything works as expected.