### PR TITLE
Add Politician reveal and campaign balancing options

### DIFF
--- a/TownOfUs/Buttons/Classic/Crewmate/CrewmatePower/PoliticianCampaignButton.cs
+++ b/TownOfUs/Buttons/Classic/Crewmate/CrewmatePower/PoliticianCampaignButton.cs
@@ -12,8 +12,11 @@ public sealed class PoliticianCampaignButton : TownOfUsRoleButton<PoliticianRole
     public override string Name => TouLocale.GetParsed("TouRolePoliticianCampaign", "Campaign");
     public override BaseKeybind Keybind => Keybinds.SecondaryAction;
     public override float Cooldown => Math.Clamp(OptionGroupSingleton<PoliticianOptions>.Instance.CampaignCooldown + MapCooldown, 5f, 120f);
+    public override int MaxUses => (int)OptionGroupSingleton<PoliticianOptions>.Instance.MaxCampaigns;
     public override Color TextOutlineColor => TownOfUsColors.Politician;
     public override LoadableAsset<Sprite> Sprite => LegacyAssets.IsLegacy ? LegacyCrewAssets.CampaignButtonSprite : TouCrewAssets.CampaignButtonSprite;
+
+    public override bool ZeroIsInfinite { get; set; } = true;
 
     public override bool CanUse()
     {

--- a/TownOfUs/Events/Crewmate/PoliticianEvents.cs
+++ b/TownOfUs/Events/Crewmate/PoliticianEvents.cs
@@ -1,0 +1,33 @@
+﻿using MiraAPI.Events;
+using MiraAPI.Events.Vanilla.Meeting;
+using MiraAPI.GameOptions;
+using MiraAPI.Hud;
+using TownOfUs.Buttons.Crewmate;
+using TownOfUs.Options.Roles.Crewmate;
+using TownOfUs.Roles.Crewmate;
+
+namespace TownOfUs.Events.Crewmate;
+
+public static class PoliticianEvents
+{
+    [RegisterEvent]
+    public static void EjectionEventEventHandler(EjectionEvent _)
+    {
+        var maxCampaigns = (int)OptionGroupSingleton<PoliticianOptions>.Instance.MaxCampaigns;
+        var button = CustomButtonSingleton<PoliticianCampaignButton>.Instance;
+        var prevented = PlayerControl.LocalPlayer.Data.Role is PoliticianRole { CanCampaign: false };
+
+        button.SetUses(prevented ? 0 : maxCampaigns);
+
+        if (!prevented && maxCampaigns == 0)
+        {
+            button.Button?.usesRemainingText.gameObject.SetActive(false);
+            button.Button?.usesRemainingSprite.gameObject.SetActive(false);
+        }
+        else
+        {
+            button.Button?.usesRemainingText.gameObject.SetActive(true);
+            button.Button?.usesRemainingSprite.gameObject.SetActive(true);
+        }
+    }
+}

--- a/TownOfUs/Options/Roles/Crewmate/PoliticianOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/PoliticianOptions.cs
@@ -12,6 +12,12 @@ public sealed class PoliticianOptions : AbstractRoleOptionGroup<PoliticianRole>
     [ModdedNumberOption("TouOptionPoliticianCampaignCooldown", 5f, 120f, 2.5f, MiraNumberSuffixes.Seconds)]
     public float CampaignCooldown { get; set; } = 25f;
 
+    [ModdedNumberOption("TouOptionPoliticianMaxCampaignsPerRound", 0f, 15f, 1f, MiraNumberSuffixes.None, "0", true)]
+    public float MaxCampaigns { get; set; } = 0f;
+
     [ModdedToggleOption("TouOptionPoliticianPreventCampaignOnFailedReveal")]
     public bool PreventCampaign { get; set; } = true;
+
+    [ModdedToggleOption("TouOptionPoliticianRequireCampaignedCrewmate")]
+    public bool RequireCampaignedCrewmate { get; set; } = true;
 }

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1198,9 +1198,13 @@
   <string name="TouRolePoliticianRevealWiki">Reveal (Meeting)</string>
   <string name="TouRolePoliticianRevealWikiDescription">If you reveal, and you have more than half of the crewmates campaigned (or no other crewmates remain), you will become the Mayor! Otherwise, your ability will fail.</string>
   <string name="TouRolePoliticianRevealWikiDescriptionPunished">If you reveal, and you have more than half of the crewmates campaigned (or no other crewmates remain), you will become the Mayor! Otherwise, your ability will fail and you cannot campaign the following round.</string>
+  <string name="TouRolePoliticianRevealWikiDescriptionRequired">If you reveal, and you have more than half of the crewmates campaigned, you will become the Mayor! Otherwise, your ability will fail.</string>
+  <string name="TouRolePoliticianRevealWikiDescriptionPunishedRequired">If you reveal, and you have more than half of the crewmates campaigned, you will become the Mayor! Otherwise, your ability will fail and you cannot campaign the following round.</string>
   <!-- Politician Options -->
   <string name="TouOptionPoliticianCampaignCooldown">Campaign Cooldown</string>
+  <string name="TouOptionPoliticianMaxCampaignsPerRound">Campaign Uses Per Round</string>
   <string name="TouOptionPoliticianPreventCampaignOnFailedReveal">Prevent Campaigning on Failed Reveal</string>
+  <string name="TouOptionPoliticianRequireCampaignedCrewmate">Require a Campaigned Crewmate to Reveal</string>
   <!-- Politician Feedback -->
   <string name="TouRolePoliticianFailedRevealCanCampaign">You need to campaign more Crewmates! You may not reveal again in this meeting.</string>
   <string name="TouRolePoliticianFailedRevealCannotCampaign">You need to campaign more Crewmates! However, you may not campaign next round.</string>

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmatePower/PoliticianRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmatePower/PoliticianRole.cs
@@ -43,15 +43,18 @@ public sealed class PoliticianRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCr
     {
         get
         {
+            var opt = OptionGroupSingleton<PoliticianOptions>.Instance;
+            var revealKey = $"TouRole{LocaleKey}RevealWikiDescription" +
+                            (opt.PreventCampaign ? "Punished" : string.Empty) +
+                            (opt.RequireCampaignedCrewmate ? "Required" : string.Empty);
+
             return
             [
                 new(TouLocale.GetParsed($"TouRole{LocaleKey}Campaign", "Campaign"),
                     TouLocale.GetParsed($"TouRole{LocaleKey}CampaignWikiDescription"),
                     TouCrewAssets.CampaignButtonSprite),
                 new(TouLocale.GetParsed($"TouRole{LocaleKey}RevealWiki", "Reveal"),
-                    TouLocale.GetParsed(OptionGroupSingleton<PoliticianOptions>.Instance.PreventCampaign
-                        ? $"TouRole{LocaleKey}RevealWikiDescriptionPunished"
-                        : $"TouRole{LocaleKey}RevealWikiDescription"),
+                    TouLocale.GetParsed(revealKey),
                     TouAssets.RevealCleanSprite)
             ];
         }
@@ -60,7 +63,10 @@ public sealed class PoliticianRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCr
     public Color RoleColor => TownOfUsColors.Politician;
     public ModdedRoleTeams Team => ModdedRoleTeams.Crewmate;
     public RoleAlignment RoleAlignment => RoleAlignment.CrewmatePower;
-    public bool IsPowerCrew => true;
+    public bool IsPowerCrew =>
+        !OptionGroupSingleton<PoliticianOptions>.Instance.RequireCampaignedCrewmate ||
+        PlayerControl.AllPlayerControls.ToArray()
+            .Any(x => !x.HasDied() && x.IsCrewmate() && x.Data.Role is not PoliticianRole); // Only stop end game checks if the politician can still reveal
 
     public CustomRoleConfiguration Configuration => new(this)
     {
@@ -160,6 +166,11 @@ public sealed class PoliticianRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITouCr
         if (aliveCrew.Count == 0)
         {
             hasMajority = true; // if all crew are dead, politician can reveal
+        }
+
+        if (OptionGroupSingleton<PoliticianOptions>.Instance.RequireCampaignedCrewmate && aliveCampaigned == 0)
+        {
+            hasMajority = false;
         }
 
         if (hasMajority)


### PR DESCRIPTION
### New 
Adds two new options **Campaign Uses Per Round** (Default: infinite)
**Require A Campaigned Crewmate To Reveal** (Default: True)

The first option is for long rounds, the host could make it so the politician doesn't campaign the whole lobby too fast and overall in general make revealing as Mayor harder since it's currently usually not too challenging.

The second option makes it so that Politician actually requires to **Campaign The Crew And Become The Mayor** instead of earning a reveal for free if all crewmates are dead. Essentially with this on **True** you need at least **1** Crewmate campaigned to be able to reveal as Mayor otherwise it will fail, this is a fair balancing setting for an already very powerful role.

Added a nice indicator on campaign button to show 0 uses upon failing reveal and being unable to campaign again when the current **Prevent Campaign on Failed Reveal** is True


 tested everything for hours on end toggle off on works, called meeting campaign use resets properly everything tested