### PR TITLE
Fix JailUnmute sprite scale

### DIFF
--- a/TownOfUs/Assets/TouAssets.cs
+++ b/TownOfUs/Assets/TouAssets.cs
@@ -465,7 +465,7 @@ public static class TouAssets
         new LoadableBundleAsset<Sprite>("Action", MainBundle);
 
     public static LoadableAsset<Sprite> JailUnmute { get; } =
-        new LoadableResourceAsset($"{ShortPath}.JailUnmute.png");
+        new LoadableResourceAsset($"{ShortPath}.JailUnmute.png", 900f);
 
     public static LoadableAsset<Sprite> MayorPet { get; } =
         new LoadableResourceAsset($"{ShortPath}.MayorPet.png", 500f);


### PR DESCRIPTION
JailUnmute previously used 900 pixels per unit. Its current LoadableResourceAsset declaration omits that value, so MiraAPI defaults to 100f and renders the artwork nine times larger.

This restores the previous 900f value explicitly.