### PR TITLE
Add option to hide player names out of sight

### DIFF
--- a/TownOfUs/Modules/Components/HudManagerHelper.cs
+++ b/TownOfUs/Modules/Components/HudManagerHelper.cs
@@ -314,6 +314,7 @@ public sealed class HudManagerHelper(nint cppPtr) : MonoBehaviour(cppPtr)
         var colorPlayerNames = LocalSettingsTabSingleton<TouLocalTabPlayers>.Instance.ColorPlayerNameToggle.Value;
         var localDead = PlayerControl.LocalPlayer.HasDied();
         var localGhost = localDead && genOpt.TheDeadKnow;
+        var hideOutOfSight = OptionGroupSingleton<VanillaTweakOptions>.Instance.HideNamesOutOfSight.Value && !localDead;
         var localImp = PlayerControl.LocalPlayer.IsImpostorAligned() &&
                        genOpt is
                            { ImpsKnowRoles.Value: true, FFAImpostorMode: false };
@@ -393,6 +394,11 @@ public sealed class HudManagerHelper(nint cppPtr) : MonoBehaviour(cppPtr)
                 }
 
                 var (playerColor, playerName) = GetRoleNameText(player, genOpt.FFAImpostorMode, taskOpt, roleNameSize, roleOnTop, colorPlayerNames, localDead, localGhost, localImp, localVamp, useMiraApiChecks, false, isVisible);
+
+                if (hideOutOfSight && !player.AmOwner && !VentPatches.InVision(player))
+                {
+                    playerName = string.Empty;
+                }
 
                 player.cosmetics.nameText.text = playerName;
                 player.cosmetics.nameText.color = playerColor;

--- a/TownOfUs/Options/VanillaTweakOptions.cs
+++ b/TownOfUs/Options/VanillaTweakOptions.cs
@@ -8,8 +8,8 @@ public sealed class VanillaTweakOptions : AbstractOptionGroup
     public override string GroupName => TouLocale.Get("TouOptionTitleVanillaTweaks");
     public override uint GroupPriority => 1;
 
-    /*[ModdedToggleOption("TouOptionHideNamesOutOfSight")]
-    public bool HideNamesOutOfSight { get; set; } = true;*/
+    public ModdedToggleOption HideNamesOutOfSight { get; set; } =
+        new("TouOptionHideNamesOutOfSight", false);
 
     public ModdedToggleOption TickCooldownsInMinigame { get; set; } =
         new("TouOptionTickCooldownsInMinigame", true);


### PR DESCRIPTION
### New
Adds a **Hide names out of sight** option that hides player names behind walls, very useful for competitive lobby's and fixes a frustrating issue stuck with the game for a long time (names clipping through walls)

Runs purely client sided (although its a host setting in Vanilla Tweaks)

**Minor issue**: None vision blocking objects like admin table also hide names if you're on the other side of it, and for that reason I chose to make the default be off, but for players who care about this settings it's absolutely worth it and doesn't negatively effect gameplay. (it can actually be good at times too)