### PR TITLE
Add an option to delay Seer comparisons until a target dies

### DIFF
--- a/TownOfUs/Options/Roles/Crewmate/SeerOptions.cs
+++ b/TownOfUs/Options/Roles/Crewmate/SeerOptions.cs
@@ -25,6 +25,11 @@ public sealed class SeerOptions : AbstractRoleOptionGroup<SeerRole>
         Visible = () => OptionGroupSingleton<SeerOptions>.Instance.SalemSeer
     };
 
+    public ModdedToggleOption DelayedCompare { get; set; } = new("TouOptionSeerDelayedCompare", false)
+    {
+        Visible = () => OptionGroupSingleton<SeerOptions>.Instance.SalemSeer
+    };
+
     public ModdedToggleOption BenignShowFriendlyToAll { get; set; } = new("TouOptionSeerNeutralBenignFriendly", false)
     {
         Visible = () => OptionGroupSingleton<SeerOptions>.Instance.SalemSeer

--- a/TownOfUs/Resources/Locale/en_US.xml
+++ b/TownOfUs/Resources/Locale/en_US.xml
@@ -1326,6 +1326,9 @@ they are friends or enemies!</string>
   <string name="TownOfUsMira.Role.SeerCompareErrorSelfNotif">You can't use yourself to compare!</string>
   <string name="TownOfUsMira.Role.SeerCompareEnemiesNotif">[gazed] and [intuited] appear to be enemies!</string>
   <string name="TownOfUsMira.Role.SeerCompareFriendsNotif">[gazed] and [intuited] appear to be friendly!</string>
+  <string name="TownOfUsMira.Role.SeerCompareDelayedNotif">You compared [gazed] and [intuited].</string>
+  <string name="TownOfUsMira.Role.SeerMessageTitle">Seer Feedback</string>
+  <string name="TownOfUsMira.Role.SeerDelayedCompareAvailable">Compare results are available after a target dies.</string>
   <string name="TownOfUsMira.Role.SeerTabHeader">Previous Comparisons:</string>
   <string name="TownOfUsMira.Role.SeerTabComparison">[gazed] vs [intuited] (Round [num])</string>
   <!-- Seer Options -->
@@ -1334,6 +1337,7 @@ they are friends or enemies!</string>
   <string name="TouOptionSeerUses">Max Uses of Reveal/Compare</string>
   <string name="TouOptionSeerMultiplePerRound">Can Reveal/Compare More Than Once Per Round</string>
   <string name="TouOptionSeerCompareEachPlayerOnce">Can Only Compare Each Player Once</string>
+  <string name="TouOptionSeerDelayedCompare">Delay Results Until A Target Dies</string>
   <string name="TouOptionSeerNeutralBenignFriendly">Neutral Benign Show Friends To All</string>
   <string name="TouOptionSeerNeutralEvilFriendly">Neutral Evils Show Friends To All</string>
   <string name="TouOptionSeerNeutralOutlierFriendly">Neutral Outliers Show Friends To All</string>

--- a/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SeerRole.cs
+++ b/TownOfUs/Roles/Classic/Crewmate/CrewmateInvestigative/SeerRole.cs
@@ -67,6 +67,7 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
     [HideFromIl2Cpp] public PlayerControl? GazeTarget { get; set; }
     [HideFromIl2Cpp] public PlayerControl? IntuitTarget { get; set; }
     [HideFromIl2Cpp] public List<PlayerControl> ComparedPlayers { get; } = [];
+    [HideFromIl2Cpp] public List<PendingComparison> PendingComparisons { get; } = [];
     public bool UsedThisRound { get; set; }
 
     public static string TabHeaderString = MiraLocaleManager.Get("TownOfUsMira.Role.SeerTabHeader");
@@ -77,6 +78,7 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
         RoleBehaviourStubs.Initialize(this, player);
         ComparisonList = [];
         ComparedPlayers.Clear();
+        PendingComparisons.Clear();
         TabHeaderString = MiraLocaleManager.Get("TownOfUsMira.Role.SeerTabHeader");
     }
 
@@ -110,6 +112,30 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
                 gazeButton.SetUses(gazeButton.UsesLeft);
                 GazeTarget = null;
             }
+
+            RevealPendingComparisons();
+        }
+    }
+
+    private void RevealPendingComparisons()
+    {
+        if (Player.HasDied() || PendingComparisons.Count == 0)
+        {
+            return;
+        }
+
+        var title = $"<color=#{TownOfUsColors.Seer.ToHtmlStringRGBA()}>{MiraLocaleManager.Get("TownOfUsMira.Role.SeerMessageTitle")}</color>";
+
+        foreach (var pending in PendingComparisons.ToArray())
+        {
+            if (!pending.First.HasDied() && !pending.Second.HasDied())
+            {
+                continue;
+            }
+
+            ComparisonList[pending.Index] = pending.Entry;
+            PendingComparisons.Remove(pending);
+            MiscUtils.AddFakeChat(Player.Data, title, pending.Message, false, true);
         }
     }
     public void SeerCompare(PlayerControl seer)
@@ -171,21 +197,27 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
 
         var players = new [] {playerA, playerB}.OrderBy(x => x.ToLowerInvariant()).ToArray();
 
-        if (enemies)
+        var resultColor = enemies ? TownOfUsColors.ImpSoft : Palette.CrewmateBlue;
+        var resultKey = enemies ? "TownOfUsMira.Role.SeerCompareEnemiesNotif" : "TownOfUsMira.Role.SeerCompareFriendsNotif";
+
+        var text = MiraLocaleManager.Get(resultKey).Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
+        var compareResult = MiraLocaleManager.Get("TownOfUsMira.Role.SeerTabComparison").Replace("<gazed>", players[0]).Replace("<intuited>", players[1])
+            .Replace("<num>", HudManagerHelper.Instance.CurrentRound.ToString(TownOfUsPlugin.Culture));
+        var resultEntry = $"<b>{resultColor.ToTextColor()}{compareResult}</color></b>";
+
+        if (OptionGroupSingleton<SeerOptions>.Instance.DelayedCompare.Value)
         {
-            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.ImpSoft));
-            var text = MiraLocaleManager.Get("TownOfUsMira.Role.SeerCompareEnemiesNotif").Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
-            ShowNotification($"<b>{TownOfUsColors.ImpSoft.ToTextColor()}{text}</color></b>");
-            var compareResult = MiraLocaleManager.Get("TownOfUsMira.Role.SeerTabComparison").Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
-            ComparisonList.Add($"<b>{TownOfUsColors.ImpSoft.ToTextColor()}{compareResult.Replace("<num>", HudManagerHelper.Instance.CurrentRound.ToString(TownOfUsPlugin.Culture))}</color></b>");
+            Coroutines.Start(MiscUtils.CoFlash(TownOfUsColors.Seer));
+            var delayed = MiraLocaleManager.Get("TownOfUsMira.Role.SeerCompareDelayedNotif").Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
+            ShowNotification($"<b>{TownOfUsColors.Seer.ToTextColor()}{delayed}</color></b>");
+            ComparisonList.Add($"<color=#BFBFBF>{compareResult}</color>");
+            PendingComparisons.Add(new PendingComparison(GazeTarget, IntuitTarget, resultEntry, text, ComparisonList.Count - 1));
         }
         else
         {
-            Coroutines.Start(MiscUtils.CoFlash(Palette.CrewmateBlue));
-            var text = MiraLocaleManager.Get("TownOfUsMira.Role.SeerCompareFriendsNotif").Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
-            ShowNotification($"<b>{Palette.CrewmateBlue.ToTextColor()}{text}</color></b>");
-            var compareResult = MiraLocaleManager.Get("TownOfUsMira.Role.SeerTabComparison").Replace("<gazed>", players[0]).Replace("<intuited>", players[1]);
-            ComparisonList.Add($"<b>{Palette.CrewmateBlue.ToTextColor()}{compareResult.Replace("<num>", HudManagerHelper.Instance.CurrentRound.ToString(TownOfUsPlugin.Culture))}</color></b>");
+            Coroutines.Start(MiscUtils.CoFlash(resultColor));
+            ShowNotification($"<b>{resultColor.ToTextColor()}{text}</color></b>");
+            ComparisonList.Add(resultEntry);
         }
 
         if (GazeTarget != null)
@@ -207,6 +239,13 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
     public StringBuilder SetTabText()
     {
         var stringB = ITownOfUsRole.SetNewTabText(this);
+        var options = OptionGroupSingleton<SeerOptions>.Instance;
+
+        if (options.SalemSeer.Value && options.DelayedCompare.Value)
+        {
+            stringB.AppendLine(TownOfUsPlugin.Culture, $"<size=60%><color=#BFBFBF>{MiraLocaleManager.Get("TownOfUsMira.Role.SeerDelayedCompareAvailable")}</color></size>");
+        }
+
         if (ComparisonList.Count != 0)
         {
             stringB.AppendLine(TownOfUsPlugin.Culture, $"\n<b>{TabHeaderString}</b>");
@@ -220,3 +259,5 @@ public sealed class SeerRole(IntPtr cppPtr) : CrewmateRole(cppPtr), ITownOfUsRol
         return stringB;
     }
 }
+
+public sealed record PendingComparison(PlayerControl First, PlayerControl Second, string Entry, string Message, int Index);


### PR DESCRIPTION
### New

New seer option: **Delay Results Until A Target Dies**

On **TRUE** it makes it so Compare results are not immediately shown to the seer and instead, get revealed to the seer in the next meeting if a target dies that round. its purely a balancing setting and its off by default to preserve current behavior.

the pending compare results are shown as gray as shown in the image below + other images:



<img width="703" height="164" alt="image" src="https://github.com/user-attachments/assets/e7fe6c62-fb5a-487e-8bb2-041261b90d7f" />
<img width="1292" height="335" alt="Image 9-4-25 at 8 05 PM" src="https://github.com/user-attachments/assets/9500b491-7c0f-4b15-9e98-d5236784df35" />
<img width="754" height="256" alt="Image 9-4-25 at 8 05 PM (1)" src="https://github.com/user-attachments/assets/4bd6afda-4507-45f2-a609-7aac2a26a68f" />

