### PR TITLE
Removed ghostwalkers ability to use the Elevator button

### DIFF
--- a/TownOfUs/Patches/HudManagerPatches.cs
+++ b/TownOfUs/Patches/HudManagerPatches.cs
@@ -554,8 +554,12 @@ public static class HudManagerPatches
                 }
             }
             if (SubmergedFloorButton && PlayerControl.LocalPlayer.Data.Role is IGhostRole ghost)
-            {
-                SubmergedFloorButton.SetActive(ghost.Caught);
+            {// Only show the floor change button to dead players who aren't active Ghostwalkers to prevent unintended floor switching.
+                SubmergedFloorButton.SetActive(
+                    PlayerControl.LocalPlayer.Data != null &&
+                    PlayerControl.LocalPlayer.Data.IsDead &&
+                    !ghost.GhostActive
+                );
             }
         }
     }

--- a/TownOfUs/Patches/SubmergedPatches.cs
+++ b/TownOfUs/Patches/SubmergedPatches.cs
@@ -47,8 +47,12 @@ public static class SubmergedHudPatch
             }
 
             if (SubmergedFloorButton)
-            {
-                SubmergedFloorButton.SetActive(!ghost.GhostActive);
+            {// Only show the floor change button to dead players who aren't active Ghostwalkers to prevent unintended floor switching.
+                SubmergedFloorButton.SetActive(
+                    PlayerControl.LocalPlayer.Data != null &&
+                    PlayerControl.LocalPlayer.Data.IsDead &&
+                    !ghost.GhostActive
+    );
             }
         }
     }


### PR DESCRIPTION
I'm not sure if it is an intended feature but Ghostwalkers could spam the floor change button, making them mostly annoying and unclickable.

Added more checks to the button without changing most of the current structure of the code.:

```
// Only show the floor change button to dead players who aren't active Ghostwalkers to prevent unintended floor switching.
                SubmergedFloorButton.SetActive(
                    PlayerControl.LocalPlayer.Data != null &&
                    PlayerControl.LocalPlayer.Data.IsDead &&
                    !ghost.GhostActive
```